### PR TITLE
feat: Add metadata tags for country and asset

### DIFF
--- a/atmos_validation/schemas/metadata.py
+++ b/atmos_validation/schemas/metadata.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import List, Union
+from typing import List, Optional, Union
 
 from pydantic import BaseModel, Field
 
@@ -48,7 +48,9 @@ class HindcastMetadata(CommonMetadata):
 class MeasurementMetadata(CommonMetadata):
     """Extra global attributes required if data_type == "Measurement"."""
 
+    asset: Optional[str]
     averaging_period: str
+    country: str
     data_usability: str
     instrument_types: str
     instrument_specifications: str

--- a/atmos_validation/schemas/metadata.py
+++ b/atmos_validation/schemas/metadata.py
@@ -46,7 +46,7 @@ class HindcastMetadata(CommonMetadata):
 
 
 class MeasurementMetadata(CommonMetadata):
-    """Extra global attributes required if data_type == "Measurement"."""
+    """Extra global attributes if data_type == "Measurement"."""
 
     asset: Optional[str]
     averaging_period: str

--- a/atmos_validation/schemas/metadata.py
+++ b/atmos_validation/schemas/metadata.py
@@ -50,7 +50,7 @@ class MeasurementMetadata(CommonMetadata):
 
     asset: Optional[str]
     averaging_period: str
-    country: str
+    country: str = Field(default="NA")
     data_usability: str
     instrument_types: str
     instrument_specifications: str

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -208,7 +208,7 @@ class HindcastMetadata(CommonMetadata):
 # ../atmos_validation/schemas/metadata.py#L48-L61
 
 class MeasurementMetadata(CommonMetadata):
-    """Extra global attributes required if data_type == "Measurement"."""
+    """Extra global attributes if data_type == "Measurement"."""
 
     asset: Optional[str]
     averaging_period: str

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -205,12 +205,14 @@ class HindcastMetadata(CommonMetadata):
 ### 3.3 Measurement
 
 ```py
-# ../atmos_validation/schemas/metadata.py#L48-L59
+# ../atmos_validation/schemas/metadata.py#L48-L61
 
 class MeasurementMetadata(CommonMetadata):
     """Extra global attributes required if data_type == "Measurement"."""
 
+    asset: Optional[str]
     averaging_period: str
+    country: str
     data_usability: str
     instrument_types: str
     instrument_specifications: str
@@ -221,7 +223,11 @@ class MeasurementMetadata(CommonMetadata):
     total_water_depth: Union[str, float]
 ```
 
+*asset*: Name of the asset which paid for the data.  In case of sharing data to the third party, permission from the asset is required.
+
 *averaging_period*: Averaging period of measurements in minutes
+
+*country*: Country name on which territory data are acquired. In case of sharing data to the third party, one need obey to country regulation rules related to data sharing.
 
 *data_usability*: Level of the data readiness
 

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -212,7 +212,7 @@ class MeasurementMetadata(CommonMetadata):
 
     asset: Optional[str]
     averaging_period: str
-    country: str
+    country: str = Field(default="NA")
     data_usability: str
     instrument_types: str
     instrument_specifications: str


### PR DESCRIPTION
Adds optional "asset" tag and mandatory "country" (but with a default value "NA" to not break existing datasets) tag to the measurements. 