### PR TITLE
fix: Make default classification_level "Internal" str

### DIFF
--- a/atmos_validation/schemas/metadata.py
+++ b/atmos_validation/schemas/metadata.py
@@ -16,9 +16,7 @@ class CommonMetadata(BaseModel, use_enum_values=True):
 
     comments: Union[List[str], str]
     contractor: str
-    classification_level: ClassificationLevel = Field(
-        default=ClassificationLevel.INTERNAL
-    )
+    classification_level: ClassificationLevel = Field(default="Internal")
     data_type: DataType
     data_history: str
     final_reports: List[str]


### PR DESCRIPTION
Bugreport from the "convert-ascii" command stated that the .nc file outputted did not automatically pass validation due to "classification_level" not being set to the enum string member value. It instead took the representation of the enum member, as seen here: 
![Screenshot 2023-11-24 at 15 58 56](https://github.com/equinor/atmos-validation/assets/44391464/915c5c7e-9331-4b25-b18f-f40123edc118)

Apperantly using the enum as the default value triggers this behaviour, so just switched it "Internal" instead. 
