### PR TITLE
fix: Set default asset to None

### DIFF
--- a/atmos_validation/schemas/metadata.py
+++ b/atmos_validation/schemas/metadata.py
@@ -51,7 +51,7 @@ class HindcastMetadata(CommonMetadata, UnprotectedNamespaceModel):
 class MeasurementMetadata(CommonMetadata):
     """Extra global attributes if data_type == "Measurement"."""
 
-    asset: Optional[str]
+    asset: Optional[str] = Field(default=None)
     averaging_period: str
     country: str = Field(default="NA")
     data_usability: str

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -208,7 +208,7 @@ class HindcastMetadata(CommonMetadata, UnprotectedNamespaceModel):
 class MeasurementMetadata(CommonMetadata):
     """Extra global attributes if data_type == "Measurement"."""
 
-    asset: Optional[str]
+    asset: Optional[str] = Field(default=None)
     averaging_period: str
     country: str = Field(default="NA")
     data_usability: str


### PR DESCRIPTION
Fixes issues with the object instantiation in Pydantic V2 which expects optional attributes to be set