### PR TITLE
feat: Update/add final_report validation to validation pipe

### DIFF
--- a/atmos_validation/validate_netcdf/tests/test_final_reports_validation.py
+++ b/atmos_validation/validate_netcdf/tests/test_final_reports_validation.py
@@ -6,34 +6,51 @@ PATH_TO_TEST_DATA = "examples/example_netcdf_measurement.nc"
 
 
 def test_final_reports_ok():
-    """Tests when final_reports is valid (a lists of string)"""
+    """Tests when final_reports is valid (a lists of string with correct extension)"""
     with xr.open_dataset(PATH_TO_TEST_DATA) as ds:
-        ds.attrs["final_reports"] = ["foo", "bar"]
+        ds.attrs["final_reports"] = ["foo.pdf", "bar.docx"]
         errors = final_reports_validator(ds)
         assert len(errors) == 0
 
 
 def test_final_reports_empty_list_ok():
-    """Tests when final_reports is valid (and empty list)"""
+    """Tests when final_reports is valid (an empty list)"""
     with xr.open_dataset(PATH_TO_TEST_DATA) as ds:
         ds.attrs["final_reports"] = []
         errors = final_reports_validator(ds)
         assert len(errors) == 0
 
 
-def test_final_reports_not_list_not_ok():
-    """Tests when final_reports is not valid (not a lists of string)"""
+def test_final_reports_empty_string_ok():
+    """Tests when final_reports is valid (an empty list)"""
     with xr.open_dataset(PATH_TO_TEST_DATA) as ds:
-        ds.attrs["final_reports"] = "this should be a list of strings"
+        ds.attrs["final_reports"] = ""
         errors = final_reports_validator(ds)
-        assert len(errors) == 1
-        assert "must be a list of strings" in errors[0]
+        assert len(errors) == 0
 
 
 def test_final_reports_list_of_non_strings_not_ok():
-    """Tests when final_reports is not valid (a lists of not all string)"""
+    """Tests when final_reports is not valid (not a string)"""
     with xr.open_dataset(PATH_TO_TEST_DATA) as ds:
-        ds.attrs["final_reports"] = ["this should be a list of strings", 3.14]
+        ds.attrs["final_reports"] = ["some_report.pdf", 1]  # wrong type
         errors = final_reports_validator(ds)
         assert len(errors) == 1
-        assert "must be a list of strings" in errors[0]
+        assert "is not comma-separated string or string list" in errors[0]
+
+
+def test_final_reports_not_string_not_ok():
+    """Tests when final_reports is not valid (not a string)"""
+    with xr.open_dataset(PATH_TO_TEST_DATA) as ds:
+        ds.attrs["final_reports"] = True  # wrong type, should be string
+        errors = final_reports_validator(ds)
+        assert len(errors) == 1
+        assert "is not comma-separated string or string list" in errors[0]
+
+
+def test_final_reports_list_wrong_file_extension_not_ok():
+    """Tests when final_reports is not valid (a lists of not all string)"""
+    with xr.open_dataset(PATH_TO_TEST_DATA) as ds:
+        ds.attrs["final_reports"] = "wrong.file_extension, one_more.error"
+        errors = final_reports_validator(ds)
+        assert len(errors) == 2
+        assert "File extension for final_reports" in errors[0]

--- a/atmos_validation/validate_netcdf/tests/test_final_reports_validation.py
+++ b/atmos_validation/validate_netcdf/tests/test_final_reports_validation.py
@@ -22,7 +22,7 @@ def test_final_reports_empty_list_ok():
 
 
 def test_final_reports_empty_string_ok():
-    """Tests when final_reports is valid (an empty list)"""
+    """Tests when final_reports is valid (an empty string)"""
     with xr.open_dataset(PATH_TO_TEST_DATA) as ds:
         ds.attrs["final_reports"] = ""
         errors = final_reports_validator(ds)
@@ -30,7 +30,7 @@ def test_final_reports_empty_string_ok():
 
 
 def test_final_reports_list_of_non_strings_not_ok():
-    """Tests when final_reports is not valid (not a string)"""
+    """Tests when final_reports is not valid (wrong type in list)"""
     with xr.open_dataset(PATH_TO_TEST_DATA) as ds:
         ds.attrs["final_reports"] = ["some_report.pdf", 1]  # wrong type
         errors = final_reports_validator(ds)
@@ -39,7 +39,7 @@ def test_final_reports_list_of_non_strings_not_ok():
 
 
 def test_final_reports_not_string_not_ok():
-    """Tests when final_reports is not valid (not a string)"""
+    """Tests when final_reports is of wrong data type"""
     with xr.open_dataset(PATH_TO_TEST_DATA) as ds:
         ds.attrs["final_reports"] = True  # wrong type, should be string
         errors = final_reports_validator(ds)
@@ -48,7 +48,7 @@ def test_final_reports_not_string_not_ok():
 
 
 def test_final_reports_list_wrong_file_extension_not_ok():
-    """Tests when final_reports is not valid (a lists of not all string)"""
+    """Tests when final_reports string includes non-valid file extensions"""
     with xr.open_dataset(PATH_TO_TEST_DATA) as ds:
         ds.attrs["final_reports"] = "wrong.file_extension, one_more.error"
         errors = final_reports_validator(ds)


### PR DESCRIPTION
Checks that:

* "final_reports" attribute is either string or list of strings (lists not supported on .nc, but is in .h5)
* if the attribute is a string it splits it on "," which is the spec (comma-separated string)
* Iterates over the final reports to check if it has a valid file extension