### PR TITLE
feat: creates data_type for single point hindcast

### DIFF
--- a/atmos_validation/schemas/metadata.py
+++ b/atmos_validation/schemas/metadata.py
@@ -9,6 +9,7 @@ from .classification_level import ClassificationLevel
 class DataType(str, Enum):
     HINDCAST = "Hindcast"
     MEASUREMENT = "Measurement"
+    SP_HINDCAST = "SinglePointHindcast"
 
 
 class UnprotectedNamespaceModel(BaseModel):
@@ -30,7 +31,7 @@ class CommonMetadata(BaseModel, use_enum_values=True):
 
 
 class HindcastMetadata(CommonMetadata, UnprotectedNamespaceModel):
-    """Extra global attributes required if data_type == "Hindcast"."""
+    """Extra global attributes required if data_type == "Hindcast" or data_type == "SinglePointHindcast"."""
 
     calibration: str
     delivery_date: str
@@ -62,9 +63,3 @@ class MeasurementMetadata(CommonMetadata):
     mooring_name: str
     source_file: str
     total_water_depth: Union[str, float]
-
-
-class SinglePointHindcastMetadata(HindcastMetadata):
-    """Extra global attributes required is data_type == "SinglePointHindcast"."""
-
-    pass

--- a/atmos_validation/schemas/metadata.py
+++ b/atmos_validation/schemas/metadata.py
@@ -62,3 +62,9 @@ class MeasurementMetadata(CommonMetadata):
     mooring_name: str
     source_file: str
     total_water_depth: Union[str, float]
+
+
+class SinglePointHindcastMetadata(HindcastMetadata):
+    """Extra global attributes required is data_type == "SinglePointHindcast"."""
+
+    pass

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -33,7 +33,7 @@
 - Timestamps shall appear in increasing order
 - Shall only contain unique values
 - The "units" attribute shall be "microseconds since 1900-01-01"
-- If source data is a hindcast, then:
+- If source data is a hindcast or single point hindcast, then:
   - The file shall be named according to the time values it contains and contain the length of the time index, in the following format: "datasetName_startTime_endTime_TtimeLenght.nc" with the corresponding time format: "YYYYMMDD". For example, a Nora10 file
   covering the whole year of 1982 and containing 2920 timestamps (a whole year with 3hr resolution) will be named e.g.: "Nora10_19820101_19821231_T2920.nc". Not adhering to startTime and endTime convention would yield a WARNING.
   - Strictly enforced: The files must be named such that they can be sorted in chronological order by timestamp values. For example, naming two files "Nora10_part1.nc" and "Nora10_part2.nc" would yield an error IF part2 contains data for a period before part1. The time-length marker "T[time_length]" is non-optional and not adhering to this convention also yields an error.
@@ -117,7 +117,7 @@ class CommonMetadata(BaseModel, use_enum_values=True):
 
 *classification_level*: Signifies data access according to classification level
 
-*data_type*: If source data is hindcast or measurement
+*data_type*: If source data is hindcast, single point hindcast, or measurement
 
 *data_history*: Any information about the origin of the data (if not measured directly by the contractor) or changes made to the data (if there has been previous versions of the same data) shall be stated here. If the data has been measured/created directly by the contractor and it is the first version delivered “Original data” shall be stated
 
@@ -130,11 +130,12 @@ class CommonMetadata(BaseModel, use_enum_values=True):
 where data_type should take either value from the enum:
 
 ```py
-# ../atmos_validation/schemas/metadata.py#L9-L11
+# ../atmos_validation/schemas/metadata.py#L9-L12
 
 class DataType(str, Enum):
     HINDCAST = "Hindcast"
     MEASUREMENT = "Measurement"
+    SP_HINDCAST = "SinglePointHindcast"
 ```
 
 The data_type value defines secondary requirements on the global attributes on the data file.
@@ -152,11 +153,13 @@ class ClassificationLevel(OrderedEnum):
 
 ### 3.2 Hindcast
 
+Single point hindcast and hindcast both use the hindcast metadata schema.
+
 ```py
 # ../atmos_validation/schemas/metadata.py#L32-L48
 
 class HindcastMetadata(CommonMetadata, UnprotectedNamespaceModel):
-    """Extra global attributes required if data_type == "Hindcast"."""
+    """Extra global attributes required if data_type == "Hindcast" or data_type == "SinglePointHindcast"."""
 
     calibration: str
     delivery_date: str

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -96,7 +96,7 @@ General instruction: When information is not available "NA" shall be used in pla
 The required common attributes can be seen underneath,
 
 ```py
-# ../atmos_validation/schemas/metadata.py#L19-L29
+# ../atmos_validation/schemas/metadata.py#L20-L30
 
 class CommonMetadata(BaseModel, use_enum_values=True):
     """Common required attributes for all data types"""
@@ -156,7 +156,7 @@ class ClassificationLevel(OrderedEnum):
 Single point hindcast and hindcast both use the hindcast metadata schema.
 
 ```py
-# ../atmos_validation/schemas/metadata.py#L32-L48
+# ../atmos_validation/schemas/metadata.py#L33-L49
 
 class HindcastMetadata(CommonMetadata, UnprotectedNamespaceModel):
     """Extra global attributes required if data_type == "Hindcast" or data_type == "SinglePointHindcast"."""
@@ -206,7 +206,7 @@ class HindcastMetadata(CommonMetadata, UnprotectedNamespaceModel):
 ### 3.3 Measurement
 
 ```py
-# ../atmos_validation/schemas/metadata.py#L51-L64
+# ../atmos_validation/schemas/metadata.py#L52-L65
 
 class MeasurementMetadata(CommonMetadata):
     """Extra global attributes if data_type == "Measurement"."""


### PR DESCRIPTION
This PR ads a new value for the new `SinglePointHindcast' DataType Enum that will be used for the upcoming vortex data. Documentation is also updated.