### PR TITLE
feat: Accept 5d spectral dimensions

### DIFF
--- a/atmos_validation/schemas/dim_constants.py
+++ b/atmos_validation/schemas/dim_constants.py
@@ -4,6 +4,8 @@ SOUTH_NORTH = "south_north"
 WEST_EAST = "west_east"
 TIME = "Time"
 HEIGHT_DIM_PREFIX = "height_"
+FREQUENCY = "frequency"
+DIRECTION = "direction"
 
 
 def get_height_dim_from_parameter_key(key: str) -> str:
@@ -18,4 +20,5 @@ def get_acceptable_dims_from_parameter_key(key: str) -> List[List[str]]:
         [TIME, SOUTH_NORTH, WEST_EAST],
         [height_dim, SOUTH_NORTH, WEST_EAST],
         [TIME, height_dim, SOUTH_NORTH, WEST_EAST],
+        [TIME, SOUTH_NORTH, WEST_EAST, FREQUENCY, DIRECTION],
     ]


### PR DESCRIPTION
Allows for parameters which has coordinates for both "frequency" and "direction". Prepares for allowing 5d spectral parameters in the Atmos Data Store. 