### PR TITLE
feat: update parameters config with qc_test

### DIFF
--- a/atmos_validation/schemas/parameter_config.py
+++ b/atmos_validation/schemas/parameter_config.py
@@ -8,7 +8,7 @@ from .dim_constants import get_acceptable_dims_from_parameter_key
 class QCTest(BaseModel):
     test_name: str = Field(default="")
     metocean_package_re: str = Field(default="")
-    default_parameters: List[Tuple[str, int]] = Field(defaut_list=list)
+    default_parameters: List[Tuple[str, int]] = Field(default_factory=list)
 
 
 class ParameterConfig(BaseModel, arbitrary_types_allowed=True, extra=Extra.allow):

--- a/atmos_validation/schemas/parameter_config.py
+++ b/atmos_validation/schemas/parameter_config.py
@@ -1,8 +1,14 @@
-from typing import Any, Dict, List, Literal, Union
+from typing import Any, Dict, List, Literal, Tuple, Union
 
-from pydantic import BaseModel, Extra, validator
+from pydantic import BaseModel, Extra, Field, validator
 
 from .dim_constants import get_acceptable_dims_from_parameter_key
+
+
+class QCTest(BaseModel):
+    test_name: str = Field(default="")
+    metocean_package_re: str = Field(default="")
+    default_parameters: List[Tuple[str, int]] = Field(defaut_list=list)
 
 
 class ParameterConfig(BaseModel, arbitrary_types_allowed=True, extra=Extra.allow):
@@ -19,6 +25,7 @@ class ParameterConfig(BaseModel, arbitrary_types_allowed=True, extra=Extra.allow
     max: Union[float, int, Literal["NA"]]
     CF_standard_name: str
     dims: List[str]
+    qc_tests: List[QCTest] = Field(default_factory=list)
 
     @validator("dims")
     @classmethod

--- a/atmos_validation/schemas/parameter_config.py
+++ b/atmos_validation/schemas/parameter_config.py
@@ -1,3 +1,4 @@
+import uuid
 from typing import Any, Dict, List, Literal, Tuple, Union
 
 from pydantic import BaseModel, Extra, Field, validator
@@ -6,8 +7,18 @@ from .dim_constants import get_acceptable_dims_from_parameter_key
 
 
 class QCTest(BaseModel):
+    """Describes a test to be run on a given parameter. QC tests are defined by metocean.
+       The default parameters are configured by those with admins access.
+
+    Args:
+        test_name: test name in atmos
+        metocean_pkg_ref: test name in the metocean package
+        default_parameters: a list of tuples, each denoting a parameter and it's default value.
+    """
+
+    test_id: int = uuid.uuid4().hex
     test_name: str = Field(default="")
-    metocean_package_re: str = Field(default="")
+    metocean_pkg_ref: str = Field(default="")
     default_parameters: List[Tuple[str, int]] = Field(default_factory=list)
 
 

--- a/atmos_validation/schemas/parameter_config.py
+++ b/atmos_validation/schemas/parameter_config.py
@@ -16,7 +16,7 @@ class QCTest(BaseModel):
         default_parameters: a list of tuples, each denoting a parameter and it's default value.
     """
 
-    test_id: int = uuid.uuid4().hex
+    test_id: str = uuid.uuid4().hex
     test_name: str = Field(default="")
     metocean_pkg_ref: str = Field(default="")
     default_parameters: List[Tuple[str, int]] = Field(default_factory=list)

--- a/atmos_validation/schemas/parameter_config.py
+++ b/atmos_validation/schemas/parameter_config.py
@@ -8,15 +8,11 @@ from .dim_constants import get_acceptable_dims_from_parameter_key
 
 class QCTest(BaseModel):
     """Describes a test to be run on a given parameter. QC tests are defined by metocean.
-       The default parameters are configured by those with admins access.
-
-    Args:
-        test_name: test name in atmos
-        metocean_pkg_ref: test name in the metocean package
-        default_parameters: a list of tuples, each denoting a parameter and it's default value.
+    The default parameters are configured by those with admins access.
     """
 
-    test_id: str = uuid.uuid4().hex
+    description: str = Field(default="")
+    test_id: str = Field(default_factory=lambda: uuid.uuid4().hex)
     test_name: str = Field(default="")
     metocean_pkg_ref: str = Field(default="")
     default_parameters: List[Tuple[str, int]] = Field(default_factory=list)


### PR DESCRIPTION
This PR adds a new schema for a QCTest, that describes a test to be used during QC process for a given parameters. 

Each Parameter can have multiple QCTests associated with it. A QCTest can also be used on different parameters (though with potentially different default values in the default_parameters list). The QCTest implementations are provided by metocean. The default parameter values are provided by persons with admin privileges. 