### PR TITLE
feat: update qc test schema

### DIFF
--- a/atmos_validation/schemas/parameter_config.py
+++ b/atmos_validation/schemas/parameter_config.py
@@ -34,7 +34,7 @@ class ParameterConfig(BaseModel, arbitrary_types_allowed=True, extra=Extra.allow
     max: Union[float, int, Literal["NA"]]
     CF_standard_name: str
     dims: List[str]
-    qc_tests: List[QCTest] = Field(default_factory=list)
+    qc_tests: Dict[str:QCTest] = Field(default_factory=list)
 
     @validator("dims")
     @classmethod

--- a/atmos_validation/schemas/parameter_config.py
+++ b/atmos_validation/schemas/parameter_config.py
@@ -34,7 +34,7 @@ class ParameterConfig(BaseModel, arbitrary_types_allowed=True, extra=Extra.allow
     max: Union[float, int, Literal["NA"]]
     CF_standard_name: str
     dims: List[str]
-    qc_tests: Dict[str:QCTest] = Field(default_factory=list)
+    qc_tests: Dict[str, QCTest] = Field(default_factory=list)
 
     @validator("dims")
     @classmethod

--- a/atmos_validation/schemas/parameter_config.py
+++ b/atmos_validation/schemas/parameter_config.py
@@ -11,11 +11,13 @@ class QCTest(BaseModel):
     The default parameters are configured by those with admins access.
     """
 
-    description: str = Field(default="")
     test_id: str = Field(default_factory=lambda: uuid.uuid4().hex)
-    test_name: str = Field(default="")
-    metocean_pkg_ref: str = Field(default="")
-    default_parameters: List[Tuple[str, int]] = Field(default_factory=list)
+    long_name: str = Field(default="")
+    metocean_pkg_ref: str = Field(default="")  # standard_name field
+    default_variables: List[Tuple[str, str, Union[int, float, Tuple], str]] = Field(
+        default_factory=list
+    )
+    description: str = Field(default="")
 
 
 class ParameterConfig(BaseModel, arbitrary_types_allowed=True, extra=Extra.allow):


### PR DESCRIPTION
This PR renames `test_name` to `long_name `since this is what it’s called in the `metocean` package, and is in-line with `long_name` field for `Parameter`s. 

It also renames `default_parameters `to `default_variable`s to avoid confusions with the atmos `Parameter`s 

It also adds new types to the `default_variables` to accommodate the different types required by the q -tests in the `metocean` package 

It also changes the` List[QCTest]` to `Dict[str, QCTest]` in the `ParameterConfig schem`a, so that the tests associated with a `Parameter` can be searched by id. This will be useful in future apis which need to modify and delete qc-tests from a `parameter` instance.