### PR TITLE
feat: add schema for wpi

### DIFF
--- a/atmos_validation/schemas/__init__.py
+++ b/atmos_validation/schemas/__init__.py
@@ -9,3 +9,4 @@ from .metadata import *
 from .parameter_config import *
 from .parameter_configs import *
 from .qc_tests import *
+from .world_port_index import *

--- a/atmos_validation/schemas/world_port_index.py
+++ b/atmos_validation/schemas/world_port_index.py
@@ -1,0 +1,28 @@
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class WorldPortIndex(BaseModel):
+    """World-wide maritime port information."""
+
+    fid: float
+    world_port_index_number: float
+    region_name: str
+    main_port_name: str
+    alternate_port_name: Optional[str] = Field(default=None)
+    unlocode: Optional[str] = Field(default=None)
+    country_code: str
+    world_water_body: str
+    tidal_range: float
+    entrance_width: float
+    channel_depth: float
+    anchorage_depth: float
+    cargo_pier_depth: float
+    oil_terminal_depth: float
+    liquified_natural_gas_terminal_depth: float
+    maximum_vessel_length: float
+    maximum_vessel_beam: float
+    maximum_vessel_draft: float
+    latitude: float
+    longitude: float

--- a/atmos_validation/schemas/world_port_index.py
+++ b/atmos_validation/schemas/world_port_index.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel, Field
 class WorldPortIndex(BaseModel):
     """World-wide maritime port information."""
 
-    fid: float
+    id: float
     world_port_index_number: float
     region_name: str
     main_port_name: str

--- a/atmos_validation/schemas/world_port_index.py
+++ b/atmos_validation/schemas/world_port_index.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, Field, field_validator
 
 
 class WorldPortIndex(BaseModel):
@@ -27,13 +27,15 @@ class WorldPortIndex(BaseModel):
     latitude: float
     longitude: float
 
-    @validator("latitude")
+    @field_validator("latitude")
+    @classmethod
     def validate_latitude(cls, lat):
         if not (-90 <= lat <= 90):
             raise ValueError(f"Invalid latitude: {lat}. It must be between -90 and 90.")
         return lat
 
-    @validator("longitude")
+    @field_validator("longitude")
+    @classmethod
     def validate_longitude(cls, lng):
         if not (-180 <= lng <= 180):
             raise ValueError(

--- a/atmos_validation/schemas/world_port_index.py
+++ b/atmos_validation/schemas/world_port_index.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, validator
 
 
 class WorldPortIndex(BaseModel):
@@ -27,14 +27,14 @@ class WorldPortIndex(BaseModel):
     latitude: float
     longitude: float
 
-    @field_validator("latitude")
+    @validator("latitude")
     @classmethod
     def validate_latitude(cls, lat):
         if not (-90 <= lat <= 90):
             raise ValueError(f"Invalid latitude: {lat}. It must be between -90 and 90.")
         return lat
 
-    @field_validator("longitude")
+    @validator("longitude")
     @classmethod
     def validate_longitude(cls, lng):
         if not (-180 <= lng <= 180):

--- a/atmos_validation/schemas/world_port_index.py
+++ b/atmos_validation/schemas/world_port_index.py
@@ -1,12 +1,12 @@
 from typing import Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, validator
 
 
 class WorldPortIndex(BaseModel):
     """World-wide maritime port information."""
 
-    id: float
+    oid: float
     world_port_index_number: float
     region_name: str
     main_port_name: str
@@ -26,3 +26,17 @@ class WorldPortIndex(BaseModel):
     maximum_vessel_draft: float
     latitude: float
     longitude: float
+
+    @validator("latitude")
+    def validate_latitude(cls, lat):
+        if not (-90 <= lat <= 90):
+            raise ValueError(f"Invalid latitude: {lat}. It must be between -90 and 90.")
+        return lat
+
+    @validator("longitude")
+    def validate_longitude(cls, lng):
+        if not (-180 <= lng <= 180):
+            raise ValueError(
+                f"Invalid longitude: {lng}. It must be between -180 and 180."
+            )
+        return lng


### PR DESCRIPTION
Adds a wpi schema to help users lookup lat, lng port names for the SeaRoutePlanner input. The required fields in the schema is provided by Lyubov.