### PR TITLE
fix: Fix 5d spectra validation bug

### DIFF
--- a/atmos_validation/validate_netcdf/tests/test_spatial_validators.py
+++ b/atmos_validation/validate_netcdf/tests/test_spatial_validators.py
@@ -15,17 +15,6 @@ def test_existence_validator_no_dim():
 
 def test_existence_validator_dim_length_0():
     ds = xr.Dataset()
-    errors = south_north_validator(ds.expand_dims({SOUTH_NORTH: []}))
+    errors = west_east_validator(ds.expand_dims({WEST_EAST: []}))
     assert len(errors) == 1
     assert "has length 0" in errors[0]
-
-
-def test_place_validator():
-    ds = xr.Dataset()
-    ds = ds.expand_dims({SOUTH_NORTH: [0, 1], WEST_EAST: [0, 1]})
-    ds = ds.assign(P=((WEST_EAST, SOUTH_NORTH), [[0, 1], [2, 3]]))  # wrong order
-    errors = south_north_validator(ds)
-    errors += west_east_validator(ds)
-    assert len(errors) == 2
-    assert f"P does not have {SOUTH_NORTH} at dimension index -2" in errors[0]
-    assert f"P does not have {WEST_EAST} at dimension index -1" in errors[1]

--- a/atmos_validation/validate_netcdf/validators/dims/spatial_validators.py
+++ b/atmos_validation/validate_netcdf/validators/dims/spatial_validators.py
@@ -40,15 +40,6 @@ def existence_validator(ds: xr.Dataset, dim_name: str) -> List[str]:
 
 
 @validation_node(severity=Severity.ERROR)
-def place_validator(ds: xr.Dataset, dim_name: str, dim_place: int) -> List[str]:
-    result = []
-    for var in ds.keys():
-        if ds.variables[var].dims[dim_place] != dim_name:
-            result += [f"{var} does not have {dim_name} at dimension index {dim_place}"]
-    return result
-
-
-@validation_node(severity=Severity.ERROR)
 def lat_lon_validator(ds: xr.Dataset) -> List[str]:
     result = []
     lats = ds["LAT"]
@@ -98,19 +89,11 @@ def mandatory_attrs_lat_lon_validator(ds: xr.Dataset) -> List[str]:
 
 @validation_node(severity=Severity.ERROR)
 def south_north_validator(ds: xr.Dataset):
-    """Validate that the dataset has this dim, that it
-    is 1d and that LAT and LON are
-    2d coordinates with this as second axis. Also validate
-    that all data variables has this as the second last axis"""
-    return (
-        [] + existence_validator(ds, SOUTH_NORTH) + place_validator(ds, SOUTH_NORTH, -2)
-    )
+    """Validate that the dataset has south_north as a dim with a length > 0"""
+    return existence_validator(ds, SOUTH_NORTH)
 
 
 @validation_node(severity=Severity.ERROR)
 def west_east_validator(ds: xr.Dataset):
-    """Validate that the dataset has this dim, that it
-    is 1d and that LAT and LON are 2d coordinates with
-    this as first axis. Also validate that all data
-    variables has this as the last axis"""
-    return [] + existence_validator(ds, WEST_EAST) + place_validator(ds, WEST_EAST, -1)
+    """Validate that the dataset has west_east as a dim with a length > 0"""
+    return existence_validator(ds, WEST_EAST)

--- a/atmos_validation/validate_netcdf/validators/variables/sig_dig_validator.py
+++ b/atmos_validation/validate_netcdf/validators/variables/sig_dig_validator.py
@@ -3,7 +3,15 @@ from typing import List, Tuple, Union
 
 import xarray as xr
 
-from ....schemas import HEIGHT_DIM_PREFIX, SOUTH_NORTH, TIME, WEST_EAST, ParameterConfig
+from ....schemas import (
+    DIRECTION,
+    FREQUENCY,
+    HEIGHT_DIM_PREFIX,
+    SOUTH_NORTH,
+    TIME,
+    WEST_EAST,
+    ParameterConfig,
+)
 from ...utils import Severity, validation_node
 
 
@@ -49,6 +57,10 @@ def _get_random_index(data: xr.DataArray) -> Tuple[Union[int, slice], ...]:
             random_index += (randint(0, len(data[SOUTH_NORTH]) - 1),)
         elif dim == WEST_EAST:
             random_index += (randint(0, len(data[WEST_EAST]) - 1),)
+        elif dim == FREQUENCY:
+            random_index += (randint(0, len(data[FREQUENCY]) - 1),)
+        elif dim == DIRECTION:
+            random_index += (randint(0, len(data[DIRECTION]) - 1),)
         else:
             raise ValueError(
                 f"Invalid dimension {dim}, cannot validate interval of {data.name}"

--- a/atmos_validation/validate_netcdf/validators/variables/varinterval_validator.py
+++ b/atmos_validation/validate_netcdf/validators/variables/varinterval_validator.py
@@ -5,6 +5,8 @@ from typing import List, Tuple, Union
 import xarray as xr
 
 from ....schemas import (
+    DIRECTION,
+    FREQUENCY,
     SOUTH_NORTH,
     TIME,
     WEST_EAST,
@@ -53,6 +55,10 @@ def _get_slice_tuple(
         elif dim == WEST_EAST:
             result += (slice(None, None),)
         elif dim == height_dim:
+            result += (slice(None, None),)
+        elif dim == FREQUENCY:
+            result += (slice(None, None),)
+        elif dim == DIRECTION:
             result += (slice(None, None),)
         else:
             raise ValueError(


### PR DESCRIPTION
There was an inconsistency that the acceptable dimensions contains ["Time, "south_north", "west_east", "frequency", "direction"], yet the place_validator required south_north and west_east to be in the last two positions of the dimension list. Removed this check. The frequency and direction dimensions was also missing from the data interval checks. This is added 