### PR TITLE
perf: Increase 5d validation performance

### DIFF
--- a/atmos_validation/schemas/dim_constants.py
+++ b/atmos_validation/schemas/dim_constants.py
@@ -6,6 +6,7 @@ TIME = "Time"
 HEIGHT_DIM_PREFIX = "height_"
 FREQUENCY = "frequency"
 DIRECTION = "direction"
+GRID_POINT_MASK = "GRID_POINT_MASK"
 
 
 def get_height_dim_from_parameter_key(key: str) -> str:

--- a/atmos_validation/validate_netcdf/main.py
+++ b/atmos_validation/validate_netcdf/main.py
@@ -49,6 +49,7 @@ def main():
             print(DOCSTRING)
         else:
             result = validate(sys.argv[2], additional_args=sys.argv[2:])
+            log.info("Validation finished")
             if isinstance(result, ValidationResult):
                 if result.errors:
                     pretty_print_result(

--- a/atmos_validation/validate_netcdf/tests/test_varinterval_validator.py
+++ b/atmos_validation/validate_netcdf/tests/test_varinterval_validator.py
@@ -34,10 +34,7 @@ def test_over_max_interval():
         ds["P"][:, 1, 0, 4] = 2  # pylint: disable=unsupported-assignment-operation
         data_array = ds["P"]
 
-        dims = ["Time", "height_P", "south_north", "west_east"]
-        errors = _check_randomly_selected_intervals_min_max(
-            data_array, test_config, dims
-        )  # type: ignore
+        errors = _check_randomly_selected_intervals_min_max(ds, data_array, test_config)  # type: ignore
         assert len(errors) == 1
         assert "overmax" in errors[0]
 
@@ -49,9 +46,6 @@ def test_under_min_interval():
         ds["P"][:, 2, 3, 2] = -1  # pylint: disable=unsupported-assignment-operation
         data_array = ds["P"]
 
-        dims = ["Time", "height_P", "south_north", "west_east"]
-        errors = _check_randomly_selected_intervals_min_max(
-            data_array, test_config, dims
-        )  # type: ignore
+        errors = _check_randomly_selected_intervals_min_max(ds, data_array, test_config)  # type: ignore
         assert len(errors) == 1
         assert "undermin" in errors[0]

--- a/atmos_validation/validate_netcdf/validators/variables/variables_validator.py
+++ b/atmos_validation/validate_netcdf/validators/variables/variables_validator.py
@@ -60,7 +60,7 @@ def variable_validator(
         + var_allowed_instruments_validator(
             key, ds, parameter_settings.allowed_instruments
         )
-        + varinterval_validator(var, parameter_settings)
+        + varinterval_validator(ds, var, parameter_settings)
         + sig_dig_validator(var, parameter_settings)
         + var_height_longname_validator(key, ds)
         + var_height_depth_validator(key, ds, parameter_settings.parameter_category)

--- a/atmos_validation/validate_netcdf/validators/variables/variables_validator.py
+++ b/atmos_validation/validate_netcdf/validators/variables/variables_validator.py
@@ -17,7 +17,7 @@ from .varattrs_validator import (
     var_required_attr_values_validator,
 )
 from .vardims_validator import vardims_validator
-from .varinterval_validator import varinterval_validator
+from .varinterval_validator import SEED, varinterval_validator
 
 
 def load_parameter_config_from_endpoint():
@@ -33,6 +33,8 @@ def load_parameter_config_from_endpoint():
 def variables_validator(ds: xr.Dataset) -> List[str]:
     valids = load_parameter_config_from_endpoint().param_dict
     errors = []
+
+    log.info("using random seed: %s", SEED)
     for key in list(ds.keys()):
         if key not in valids:
             errors += [f"{key} is not a valid key"]

--- a/atmos_validation/validate_netcdf/validators/variables/varinterval_validator.py
+++ b/atmos_validation/validate_netcdf/validators/variables/varinterval_validator.py
@@ -42,8 +42,7 @@ def _get_random_time_slice(actual: xr.DataArray, rand: random.Random) -> slice:
 
 
 def _get_random_spatial_point(
-    ds: xr.Dataset,
-    rand: random.Random,
+    ds: xr.Dataset, rand: random.Random
 ) -> tuple[slice, slice]:
     """To save processing time we check 1x1 random spatial point where GRID_POINT_MASK == 1"""
     if GRID_POINT_MASK not in ds:
@@ -58,9 +57,7 @@ def _get_random_spatial_point(
 
 
 def _get_slice_tuple(
-    ds: xr.Dataset,
-    actual: xr.DataArray,
-    rand: random.Random,
+    ds: xr.Dataset, actual: xr.DataArray, rand: random.Random
 ) -> Tuple[Union[int, slice], ...]:
     if FREQUENCY in actual.dims and len(actual.dims) == 5:
         result = ()

--- a/atmos_validation/validate_netcdf/validators/variables/varinterval_validator.py
+++ b/atmos_validation/validate_netcdf/validators/variables/varinterval_validator.py
@@ -2,11 +2,12 @@ import random
 import sys
 from typing import List, Tuple, Union
 
+import numpy as np
 import xarray as xr
 
 from ....schemas import (
-    DIRECTION,
     FREQUENCY,
+    GRID_POINT_MASK,
     SOUTH_NORTH,
     TIME,
     WEST_EAST,
@@ -19,7 +20,6 @@ from ...utils import Severity, validation_node
 from ...validation_logger import log
 
 SEED = random.randrange(sys.maxsize)
-print(f"using random seed: {SEED}")
 
 
 def _get_random_time_slice(actual: xr.DataArray, rand: random.Random) -> slice:
@@ -41,13 +41,39 @@ def _get_random_time_slice(actual: xr.DataArray, rand: random.Random) -> slice:
     return time_slice
 
 
+def _get_random_spatial_point(
+    ds: xr.Dataset,
+    rand: random.Random,
+) -> tuple[slice, slice]:
+    """To save processing time we check 1x1 random spatial point where GRID_POINT_MASK == 1"""
+    if GRID_POINT_MASK not in ds:
+        ds.assign({GRID_POINT_MASK: xr.DataArray(1, dims=(SOUTH_NORTH, WEST_EAST))})
+
+    mask = ds[GRID_POINT_MASK].values
+    valids = np.where(mask == 1)
+    indices = list(zip(valids[0], valids[1]))
+    sn_index, we_index = rand.choice(indices)
+
+    return (slice(sn_index, sn_index + 1), slice(we_index, we_index + 1))
+
+
 def _get_slice_tuple(
-    dims: List[str], actual: xr.DataArray, rand: random.Random
+    ds: xr.Dataset,
+    actual: xr.DataArray,
+    rand: random.Random,
 ) -> Tuple[Union[int, slice], ...]:
-    result: Tuple[Union[int, slice], ...] = ()
+    if FREQUENCY in actual.dims and len(actual.dims) == 5:
+        result = ()
+        result += (_get_random_time_slice(actual, rand),)
+        result += _get_random_spatial_point(ds, rand)
+        result += (slice(None, None),)
+        result += (slice(None, None),)
+        return result
+
     key = str(actual.name)
     height_dim = get_height_dim_from_parameter_key(key)
-    for dim in dims:
+    result = ()
+    for dim in actual.dims:
         if dim == TIME:
             result += (_get_random_time_slice(actual, rand),)
         elif dim == SOUTH_NORTH:
@@ -55,10 +81,6 @@ def _get_slice_tuple(
         elif dim == WEST_EAST:
             result += (slice(None, None),)
         elif dim == height_dim:
-            result += (slice(None, None),)
-        elif dim == FREQUENCY:
-            result += (slice(None, None),)
-        elif dim == DIRECTION:
             result += (slice(None, None),)
         else:
             raise ValueError(
@@ -100,7 +122,9 @@ def none_larger_than_max_validator(
 
 
 @validation_node(severity=Severity.ERROR)
-def varinterval_validator(actual: xr.DataArray, expected: ParameterConfig) -> List[str]:
+def varinterval_validator(
+    ds: xr.Dataset, actual: xr.DataArray, expected: ParameterConfig
+) -> List[str]:
     """
     Take a bunch of random intervals in
     time, height, south_north, west_east
@@ -109,37 +133,37 @@ def varinterval_validator(actual: xr.DataArray, expected: ParameterConfig) -> Li
     """
     log.info("validating interval for %s", actual.name)
     dims = [str(dim) for dim in actual.dims]
-    accept = get_acceptable_dims_from_parameter_key(str(actual.name))
-
-    result = []
-    if dims not in accept:
+    accepted = get_acceptable_dims_from_parameter_key(str(actual.name))
+    if dims not in accepted:
         return [
             f"Unsupported dimensional layout {dims}. Cannot evaluate interval. Accepted dimensional"
-            f" layouts: {accept}"
+            f" layouts: {accepted}"
         ]
+
+    result = []
     if validation_settings.should_check_min_max_full():
         # Long running operation, so have to explicitly request this in args
         result += none_less_than_min_validator(actual, expected)
         result += none_larger_than_max_validator(actual, expected)
         return result
-    # Seed the randomizer. We want what is called here to be reproducible
     if validation_settings.should_skip_min_max_check():
         return []
-    return _check_randomly_selected_intervals_min_max(actual, expected, dims)
+    return _check_randomly_selected_intervals_min_max(ds, actual, expected)
 
 
 def _check_randomly_selected_intervals_min_max(
-    actual: xr.DataArray, expected: ParameterConfig, dims: List[str]
+    ds: xr.Dataset, actual: xr.DataArray, expected: ParameterConfig
 ):
     rand = random.Random(SEED)
-    result = []
+    log.info("using random seed: %s", SEED)
 
-    slice_tuple = _get_slice_tuple(dims, actual, rand)
+    slice_tuple = _get_slice_tuple(ds, actual, rand)
     vals = actual[slice_tuple]
     vals.load()
+
+    result = []
     result += undermin_validator(actual, expected, slice_tuple, vals)
     result += overmax_validator(actual, expected, slice_tuple, vals)
-
     return result
 
 

--- a/atmos_validation/validate_netcdf/validators/variables/varinterval_validator.py
+++ b/atmos_validation/validate_netcdf/validators/variables/varinterval_validator.py
@@ -152,7 +152,6 @@ def _check_randomly_selected_intervals_min_max(
     ds: xr.Dataset, actual: xr.DataArray, expected: ParameterConfig
 ):
     rand = random.Random(SEED)
-    log.info("using random seed: %s", SEED)
 
     slice_tuple = _get_slice_tuple(ds, actual, rand)
     vals = actual[slice_tuple]


### PR DESCRIPTION
To speed up the spectra / 5D variables case, only grab a single valid (valid means GRID_POINT_MASK == 1) point from the grid for validating parameter value-range