### PR TITLE
feat: add qc_domain field to measurements metadata

### DIFF
--- a/atmos_validation/schemas/metadata.py
+++ b/atmos_validation/schemas/metadata.py
@@ -63,4 +63,4 @@ class MeasurementMetadata(CommonMetadata):
     mooring_name: str
     source_file: str
     total_water_depth: Union[str, float]
-    qc_domain: List[str] = Field(default=[])
+    qc_domain: str = Field(default="")

--- a/atmos_validation/schemas/metadata.py
+++ b/atmos_validation/schemas/metadata.py
@@ -63,3 +63,4 @@ class MeasurementMetadata(CommonMetadata):
     mooring_name: str
     source_file: str
     total_water_depth: Union[str, float]
+    qc_domain: str = Field(default="")

--- a/atmos_validation/schemas/metadata.py
+++ b/atmos_validation/schemas/metadata.py
@@ -63,4 +63,4 @@ class MeasurementMetadata(CommonMetadata):
     mooring_name: str
     source_file: str
     total_water_depth: Union[str, float]
-    qc_domain: str = Field(default="")
+    qc_domain: List[str] = Field(default=[])


### PR DESCRIPTION
adding a new field to the measurement metadata. 

the qc_domain field will hold the the path to the location of a zarr store on Omnia Data Lake that holds the QC results which have been run on that Measurement.