### PR TITLE
fix: add validator to key fields on config types

### DIFF
--- a/atmos_validation/schemas/data_usability_level.py
+++ b/atmos_validation/schemas/data_usability_level.py
@@ -1,6 +1,15 @@
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 class DataUsabilityLevel(BaseModel):
     level: str
     description: str = Field(default="")
+
+    @field_validator("level")
+    @classmethod
+    def validate_level(cls, level: str) -> str:
+        """level should not be empty or contain unnecessary white space"""
+
+        if not level.strip():
+            raise ValueError("level should not be empty or contain only white space")
+        return level.strip()

--- a/atmos_validation/schemas/installation_type.py
+++ b/atmos_validation/schemas/installation_type.py
@@ -1,6 +1,17 @@
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 class InstallationType(BaseModel):
     installation_type: str
     description: str = Field(default="")
+
+    @field_validator("installation_type")
+    @classmethod
+    def validate_installation_type(cls, installation_type: str) -> str:
+        """installation_type should not be empty or contain unnecessary white space"""
+
+        if not installation_type.strip():
+            raise ValueError(
+                "installation_type should not be empty or contain only white space"
+            )
+        return installation_type.strip()

--- a/atmos_validation/schemas/instrument_type.py
+++ b/atmos_validation/schemas/instrument_type.py
@@ -1,6 +1,17 @@
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 class InstrumentType(BaseModel):
     instrument_type: str
     description: str = Field(default="")
+
+    @field_validator("instrument_type")
+    @classmethod
+    def validate_instrument_type(cls, instrument_type: str) -> str:
+        """instrument_type should not be empty or contain unnecessary white space"""
+
+        if not instrument_type.strip():
+            raise ValueError(
+                "instrument_type should not be empty or contain only white space"
+            )
+        return instrument_type.strip()

--- a/atmos_validation/schemas/parameter_config.py
+++ b/atmos_validation/schemas/parameter_config.py
@@ -43,6 +43,15 @@ class ParameterConfig(BaseModel, extra="allow"):
     dims: List[str]
     qc_tests: Dict[str, QCTest] = Field(default_factory=dict)
 
+    @field_validator("key")
+    @classmethod
+    def validate_key(cls, key: str) -> str:
+        """key should not be empty or contain unnecessary white space"""
+
+        if not key.strip():
+            raise ValueError("key should not be empty or contain only white space")
+        return key.strip()
+
     @field_validator("dims")
     @classmethod
     def validate_dims(cls, dims: List[str], info: ValidationInfo):


### PR DESCRIPTION
This PR adds a field validator to the identifying fields for the ConfigTypes: ParameterConfig, InstrumentType, InstallationType, and DataUsability. The validator checks the identifying field for that config type (key, instrument_type, Installation_type, level) to make sure it is not empty string, or a string of white space. It returns the identifying field with leading and trailing space removed, or an error.