### PR TITLE
fix(validate-netcdf): exit non-zero when validate-netcdf fails

### DIFF
--- a/atmos_validation/validate_netcdf/main.py
+++ b/atmos_validation/validate_netcdf/main.py
@@ -44,28 +44,33 @@ Options:
 def main():
     log.create_or_update_logger()
     log.info(sys.argv)
+    if len(sys.argv) <= 2:
+        print(DOCSTRING)
+        sys.exit(2)
+
     try:
-        if len(sys.argv) <= 2:
-            print(DOCSTRING)
-        else:
-            result = validate(sys.argv[2], additional_args=sys.argv[2:])
-            log.info("Validation finished")
-            if isinstance(result, ValidationResult):
-                if result.errors:
-                    pretty_print_result(
-                        result.errors,
-                        description=f"Found {len(result.errors)} errors. These must be fixed:",
-                    )
-                if result.warnings:
-                    pretty_print_result(
-                        result.warnings,
-                        description=f"Found {len(result.warnings)} warnings. These are FYI and can be ignored:",
-                    )
-                if not result.warnings + result.errors:
-                    print("Looks good! File validated with 0 errors and 0 warnings")
+        result = validate(sys.argv[2], additional_args=sys.argv[2:])
     except Exception as e:
         log.error(e)
-        print(DOCSTRING)
+        print(f"Validation failed with an unexpected error: {e!r}")
+        sys.exit(1)
+
+    log.info("Validation finished")
+    if result.errors:
+        pretty_print_result(
+            result.errors,
+            description=f"Found {len(result.errors)} errors. These must be fixed:",
+        )
+    if result.warnings:
+        pretty_print_result(
+            result.warnings,
+            description=f"Found {len(result.warnings)} warnings. These are FYI and can be ignored:",
+        )
+    if not result.warnings + result.errors:
+        print("Looks good! File validated with 0 errors and 0 warnings")
+
+    if result.errors:
+        sys.exit(1)
 
 
 def validate(


### PR DESCRIPTION
## Summary

The `validate-netcdf` CLI previously **failed open**: it printed validation errors (e.g. `Found 1 errors`) but exited with code `0`, and it caught unexpected exceptions by printing the usage docstring while still exiting `0`. This meant automated callers (CI pipelines, shell scripts, pre-commit hooks) had no reliable way to detect that validation failed.

## Changes

Scoped to the CLI entry point (`main()`) in `atmos_validation/validate_netcdf/main.py`:

- **Exit `1`** when validation produces errors.
- **Exit `1`** on unexpected exceptions, printing an explicit error message instead of the usage text (usage text wrongly implied a user input mistake and hid real crashes).
- **Exit `2`** when the required argument is missing (conventional CLI-misuse code).

## Not changed

The library `validate()` function is intentionally left untouched — it still returns a `ValidationResult` without raising or calling `sys.exit`, so programmatic consumers keep full control over how they handle failures. Only the CLI, whose machine-readable contract is its exit code, now signals failure.

## Verification

- Nonexistent file → exits `1`
- Valid file → exits `0`
- Existing `validate_netcdf/tests/test_main.py` suite passes (tests exercise `validate()` directly, unaffected)