### PR TITLE
fix(validate-netcdf): validate all local files as one sorted dataset

### DIFF
--- a/atmos_validation/validate_netcdf/main.py
+++ b/atmos_validation/validate_netcdf/main.py
@@ -37,7 +37,6 @@ Options:
     \t\t\t\t\t Can be extremely slow for large datasets. Default behaviour is taking random samples.
     --{validation_settings.SKIP_MIN_MAX_CHECK} \t Skip random sample check for min/max values.
     --{validation_settings.SKIP_WARNINGS} \t\t\t Skip all checks that would only output a "WARNING".
-    --{validation_settings.BATCH_SIZE} \t\t\t Set the amount of .nc files per batch to validate. Defaults to 1000.
 """
 
 
@@ -72,7 +71,6 @@ def validate(
     path: str,
     injected_logger: Optional[logging.Logger] = None,
     additional_args: Optional[List[str]] = None,
-    batch_size: Optional[int] = None,
 ) -> ValidationResult:
     """
     Execute validation on a directory or file.
@@ -83,8 +81,6 @@ def validate(
         than the ones included in the set under validation
         injected_logger: pass a logger to be used for validation
         additional_args: see docstring "Options" for available additional_args.
-        batch_size: Since open_mfdataset is slow for opening large amount of files,
-        validation can be run in batches. Defaults to 1000 files per open_mfdataset/batch.
 
     Returns:
         ValidationResult containing errors and warning from running validation
@@ -92,14 +88,11 @@ def validate(
     log.create_or_update_logger(injected_logger)
     if additional_args:
         validation_settings.apply_settings(additional_args)
-    if batch_size:
-        validation_settings.set_batch_size(override=batch_size)
 
     try:
         log.info("load dataset from path %s", path)
-        batches = load_paths(path, batch_size=validation_settings.get_batch_size())
-        validation_settings.NO_OF_BATCHES = len(batches)
-        if not batches:
+        paths = load_paths(path)
+        if not paths:
             raise OSError("No NetCDF files in dir")
     except Exception as err:
         return ValidationResult(
@@ -109,18 +102,12 @@ def validate(
 
     ds = None
     try:
-        warnings = []
-        for i, batch in enumerate(batches):
-            print(f"validating batch: {i+1} of {len(batches)}")
-            ds = open_mf_dataset(batch)
-            batch_result = root_validator(ds, batch)
-            warnings += batch_result.warnings
-            if batch_result.errors:  # early exit if error occurs in batch
-                return ValidationResult(
-                    warnings=list(set(warnings)),
-                    errors=batch_result.errors,
-                )
-        return ValidationResult(warnings=list(set(warnings)), errors=[])
+        ds = open_mf_dataset(paths)
+        result = root_validator(ds, paths)
+        return ValidationResult(
+            warnings=list(set(result.warnings)),
+            errors=result.errors,
+        )
     except Exception as err:
         return ValidationResult(errors=[repr(err)], warnings=[])
     finally:
@@ -128,7 +115,7 @@ def validate(
             ds.close()
 
 
-def load_paths(path: str, batch_size: int) -> List[List[str]]:
+def load_paths(path: str) -> List[str]:
     """
     Parameters
     ----------
@@ -137,14 +124,8 @@ def load_paths(path: str, batch_size: int) -> List[List[str]]:
     than the ones included in the set under validation
     """
     if path.endswith(".nc"):
-        paths = [path]
-    else:
-        paths = get_file_paths_in_folder(path)
-    batches = []
-    for i in range(0, len(paths), batch_size):
-        batch = paths[i : i + batch_size]
-        batches.append(batch)
-    return batches
+        return [path]
+    return get_file_paths_in_folder(path)
 
 
 def open_mf_dataset(paths: List[str]) -> xr.Dataset:

--- a/atmos_validation/validate_netcdf/utils.py
+++ b/atmos_validation/validate_netcdf/utils.py
@@ -17,14 +17,11 @@ class Severity(str, Enum):
 
 
 def get_file_paths_in_folder(folder_path: str, filetype: str = ".nc") -> List[str]:
-    paths = []
-    for _, _, filenames in os.walk(folder_path):
-        for filename in filenames:
-            if filename.endswith(filetype):
-                filepath = os.path.join(folder_path, filename)
-                paths.append(filepath)
-        break
-    return paths
+    return sorted(
+        os.path.join(folder_path, name)
+        for name in os.listdir(folder_path)
+        if name.endswith(filetype)
+    )
 
 
 def validation_node(

--- a/atmos_validation/validate_netcdf/validation_settings.py
+++ b/atmos_validation/validate_netcdf/validation_settings.py
@@ -11,9 +11,6 @@ SKIP_MIN_MAX_CHECK: str = "--skip-random-min-max-check"
 SKIP_WARNINGS: str = "--skip-warnings"
 URL_TO_PARAMETERS: str = "--set-url-to-parameters="
 DEFAULT_URL_TO_PARAMETERS: str = "https://atmos.app.radix.equinor.com/config/parameters"
-BATCH_SIZE: str = "--batch-size="
-DEFAULT_BATCH_SIZE = 1000
-NO_OF_BATCHES: int
 SETTINGS = set()
 
 
@@ -28,30 +25,6 @@ def get_url_to_parameters() -> str:
             return str(arg).split(URL_TO_PARAMETERS, 1)[1].strip()
     # Not supplied, return default
     return DEFAULT_URL_TO_PARAMETERS
-
-
-def set_batch_size(override: int):
-    batch_size_argument = None
-    for arg in SETTINGS:
-        if str(arg).startswith(BATCH_SIZE):
-            batch_size_argument = arg
-
-    if batch_size_argument:
-        SETTINGS.remove(batch_size_argument)
-
-    SETTINGS.add(f"{BATCH_SIZE}{override}")
-
-
-def get_batch_size() -> int:
-    batch_size = DEFAULT_BATCH_SIZE
-    for arg in SETTINGS:
-        if str(arg).startswith(BATCH_SIZE):
-            try:
-                batch_size = int(str(arg).split(BATCH_SIZE, 1)[1].strip())
-            except ValueError as e:
-                raise TypeError("Batch size must be an integer") from e
-    print(f"using batch_size = {batch_size}")
-    return batch_size
 
 
 def should_skip_min_max_check() -> bool:

--- a/atmos_validation/validate_netcdf/validators/variables/varinterval_validator.py
+++ b/atmos_validation/validate_netcdf/validators/variables/varinterval_validator.py
@@ -25,7 +25,7 @@ SEED = random.randrange(sys.maxsize)
 def _get_random_time_slice(actual: xr.DataArray, rand: random.Random) -> slice:
     """To save processing time we only check 5000 timestamps random samples"""
     len_time = len(actual.Time)
-    sample_size = 5000 // validation_settings.NO_OF_BATCHES
+    sample_size = 5000
     if len_time > sample_size * 2:
         start = rand.randint(0, len_time - sample_size - 1)
         time_slice = slice(


### PR DESCRIPTION
## Summary

Validation results previously depended on filesystem order and `batch_size`. Files were discovered unsorted (`os.walk`) and each batch was validated independently, so **duplicate or reversed timestamps that straddle a batch boundary could pass undetected**, and the same dataset could produce different results depending on how files were discovered and chunked.

Batching only ever existed to work around using NetCDF over Azure blob storage — an unsupported pattern (the B-tree traversal over HTTP is fundamentally unworkable). Validation is meant to run against **local** files, where a single `open_mfdataset` scales to whatever fits on disk.

## Changes

- **`validate()`** now opens **all** local files in a single `open_mfdataset` and runs `root_validator` once, so cross-file time checks (duplicate/monotonic timestamps) see the entire dataset. `load_paths()` returns a flat `List[str]` instead of batches.
- **`get_file_paths_in_folder`** now returns a `sorted(os.listdir(...))` listing instead of `os.walk`+`break`, so concatenation order is deterministic and chronological (fixes the "discovered unsorted" half of the problem).
- Removed the `--batch-size` CLI option and the `BATCH_SIZE` / `DEFAULT_BATCH_SIZE` / `NO_OF_BATCHES` / `set_batch_size` / `get_batch_size` machinery from `validation_settings`.
- `varinterval_validator` sample size is a fixed `5000` (previously `5000 // NO_OF_BATCHES`).

## Not in scope

A configurable `--sample-size` argument is deliberately left for a follow-up PR. This change is strictly about removing `batch_size` and its role in the order-dependent validation bug.

## Verification

- All 50 `validate_netcdf` tests pass.
- Directory validation smoke test (`examples/hindcast_example`, 3 files) → 0 errors, exit 0.