### PR TITLE
fix(validate-netcdf): Reject files referencing external HDF5 storage

### DIFF
--- a/atmos_validation/validate_netcdf/external_reference_guard.py
+++ b/atmos_validation/validate_netcdf/external_reference_guard.py
@@ -1,0 +1,62 @@
+"""Reject HDF5/NetCDF files that reference storage outside themselves.
+
+HDF5 external storage, external links and virtual datasets make a variable's
+bytes resolve from a separate, file-embedded path only when the data is *read*.
+Inspecting metadata does not dereference them, so untrusted files can be
+screened and rejected before anything is opened through xarray/h5py.
+"""
+
+from typing import List, Set
+
+import h5py
+import h5py.h5o as h5o
+
+
+class ExternalReferenceError(Exception):
+    """Raised when a file points at storage outside itself."""
+
+
+def assert_no_external_references(paths: List[str]) -> None:
+    """Raise ExternalReferenceError if any file uses external storage, an
+    external link or a virtual dataset. Only metadata is read, never data."""
+    for path in paths:
+        with h5py.File(path, "r") as file:
+            findings: List[str] = []
+            _scan_group(file, findings, set())
+            if findings:
+                raise ExternalReferenceError(
+                    f"Refusing to open {path}: it references storage outside the file "
+                    f"({'; '.join(findings)}). External storage, external links and "
+                    "virtual datasets are not permitted."
+                )
+
+
+def _scan_group(group: h5py.Group, findings: List[str], visited: Set[int]) -> None:
+    for key in group.keys():
+        # Inspect the link itself first so external links are never dereferenced.
+        link = group.get(key, getlink=True)
+        if isinstance(link, h5py.ExternalLink):
+            parent = (group.name or "").rstrip("/")
+            findings.append(f"external link '{parent}/{key}' -> {link.filename}")
+            continue
+        if isinstance(link, h5py.SoftLink):
+            # Stays within the file; its hard-linked target is scanned on its own.
+            continue
+
+        item = group[key]
+        addr = h5o.get_info(item.id).addr
+        if addr in visited:  # guard against cyclic hard links
+            continue
+        visited.add(addr)
+
+        if isinstance(item, h5py.Group):
+            _scan_group(item, findings, visited)
+        elif isinstance(item, h5py.Dataset):
+            _scan_dataset(item, findings)
+
+
+def _scan_dataset(dataset: h5py.Dataset, findings: List[str]) -> None:
+    if dataset.is_virtual:
+        findings.append(f"virtual dataset '{dataset.name}'")
+    if dataset.id.get_create_plist().get_external_count() > 0:
+        findings.append(f"external storage '{dataset.name}'")

--- a/atmos_validation/validate_netcdf/main.py
+++ b/atmos_validation/validate_netcdf/main.py
@@ -20,6 +20,10 @@ from typing import List, Optional
 import xarray as xr
 
 from . import validation_settings
+from .external_reference_guard import (
+    ExternalReferenceError,
+    assert_no_external_references,
+)
 from .utils import get_file_paths_in_folder
 from .validation_logger import log
 from .validators.root_validator import ValidationResult, root_validator
@@ -102,12 +106,15 @@ def validate(
 
     ds = None
     try:
+        assert_no_external_references(paths)
         ds = open_mf_dataset(paths)
         result = root_validator(ds, paths)
         return ValidationResult(
             warnings=list(set(result.warnings)),
             errors=result.errors,
         )
+    except ExternalReferenceError as err:
+        return ValidationResult(errors=[f"file:{err}"], warnings=[])
     except Exception as err:
         return ValidationResult(errors=[repr(err)], warnings=[])
     finally:

--- a/atmos_validation/validate_netcdf/tests/test_external_reference_guard.py
+++ b/atmos_validation/validate_netcdf/tests/test_external_reference_guard.py
@@ -1,0 +1,64 @@
+import h5py
+import numpy as np
+import pytest
+
+from ..external_reference_guard import (
+    ExternalReferenceError,
+    assert_no_external_references,
+)
+
+
+def _write_units(dataset: h5py.Dataset) -> None:
+    dataset.attrs["units"] = "microseconds since 1900-01-01"
+
+
+def test_clean_file_passes(tmp_path):
+    path = tmp_path / "clean.nc"
+    with h5py.File(path, "w") as file:
+        _write_units(file.create_dataset("Time", data=np.arange(10, dtype="int64")))
+
+    assert_no_external_references([str(path)])
+
+
+def test_external_storage_is_rejected(tmp_path):
+    secret = tmp_path / "secret.bin"
+    np.arange(10, dtype="int64").tofile(secret)
+    path = tmp_path / "ext_storage.nc"
+    with h5py.File(path, "w") as file:
+        _write_units(
+            file.create_dataset(
+                "Time",
+                shape=(10,),
+                dtype="int64",
+                external=[(str(secret), 0, h5py.h5f.UNLIMITED)],
+            )
+        )
+
+    with pytest.raises(ExternalReferenceError, match="external storage"):
+        assert_no_external_references([str(path)])
+
+
+def test_external_link_is_rejected(tmp_path):
+    target = tmp_path / "target.nc"
+    with h5py.File(target, "w") as file:
+        _write_units(file.create_dataset("Time", data=np.arange(10, dtype="int64")))
+    path = tmp_path / "with_extlink.nc"
+    with h5py.File(path, "w") as file:
+        file["Time"] = h5py.ExternalLink(str(target), "Time")
+
+    with pytest.raises(ExternalReferenceError, match="external link"):
+        assert_no_external_references([str(path)])
+
+
+def test_virtual_dataset_is_rejected(tmp_path):
+    source = tmp_path / "source.nc"
+    with h5py.File(source, "w") as file:
+        file.create_dataset("Time", data=np.arange(10, dtype="int64"))
+    path = tmp_path / "vds.nc"
+    layout = h5py.VirtualLayout(shape=(10,), dtype="int64")
+    layout[:] = h5py.VirtualSource(str(source), "Time", shape=(10,))
+    with h5py.File(path, "w") as file:
+        _write_units(file.create_virtual_dataset("Time", layout))
+
+    with pytest.raises(ExternalReferenceError, match="virtual dataset"):
+        assert_no_external_references([str(path)])


### PR DESCRIPTION
## Summary

Adds a pre-open guard that rejects untrusted HDF5/NetCDF files which reference storage **outside** the file itself, closing a verified information-disclosure / DoS vector.

## Background

HDF5 **external storage**, **external links**, and **virtual datasets** make a variable's bytes resolve from a separate, file-embedded path *when the data is read*. Because the validator opens provider-supplied files (via `xr.open_dataset(engine="h5netcdf")` and direct `h5py.File` reads) and echoes sampled values back in its output, a crafted file can point `Time` (or any variable) at an arbitrary local path and leak its contents, or cause a DoS by pointing at `/dev/zero`, a huge file, or a blocking FIFO. This was reproduced against the installed h5py 3.16.0 / HDF5 2.0.0 (external storage read succeeds on a non-HDF5 raw file; the S3/HTTP VFDs are not compiled in, so the reliable primitive is local-file read).

Switching to xarray-only reads does **not** help — `h5netcdf` sits on the same libhdf5 and honors the same features.

## Change

New module `external_reference_guard.py` with `assert_no_external_references(paths)`:
- Opens each file read-only and walks the object tree using **metadata only** — it never dereferences, so scanning is safe.
- Rejects with a clear `ExternalReferenceError` if any object uses:
  - **external storage** (`get_external_count() > 0`) — the raw-bytes local-read primitive
  - **external links** (`h5py.ExternalLink`, detected via `get(..., getlink=True)` so the link is flagged, not followed)
  - **virtual datasets** (`is_virtual`)
- Guards against cyclic hard links via a visited-address set.

Wired into `validate()` **before** `open_mf_dataset` and before any h5py reads; on rejection it returns a `ValidationResult` error (`file:Refusing to open ...`), fail-closed, with no data touched.

## Performance

Metadata-only scan, independent of data volume. Benchmarked at ~0.8 ms/file warm and ~4 ms/file cold — roughly **1–4 s for 1000 files**, negligible next to the existing data-sampling validators.

## Tests

`test_external_reference_guard.py`: clean file passes; external storage, external link, and virtual dataset each rejected. Existing `test_main` / `test_time_validator` still pass, and the real example datasets pass the guard.

## Notes

- Base is `fix/2514-false-negatives` intentionally (stacked on the range-validation fixes); will follow that branch onto main.
- This is an application-layer defense; pairs with a filesystem/network sandbox for residual DoS/SSRF, but addresses the external-reference vector directly.