### PR TITLE
fix(validate-netcdf): Harden config downloads and remove configurable URL

### DIFF
--- a/atmos_validation/validate_netcdf/utils.py
+++ b/atmos_validation/validate_netcdf/utils.py
@@ -4,11 +4,36 @@ from enum import Enum
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, TypeVar
 
 import pandas as pd
+import requests
 import xarray as xr
 
 from atmos_validation.validate_netcdf import validation_settings
 
 from .validation_logger import log
+
+CONFIG_REQUEST_TIMEOUT_SECONDS = 10
+MAX_CONFIG_RESPONSE_BYTES = 10 * 1024 * 1024  # 10 MB
+
+
+class ConfigDownloadError(Exception):
+    """Raised when a configuration endpoint cannot be downloaded safely."""
+
+
+def fetch_config_bytes(url: str) -> bytes:
+    """Download config JSON with a request timeout and a bounded response size."""
+    with requests.get(
+        url, timeout=CONFIG_REQUEST_TIMEOUT_SECONDS, stream=True
+    ) as response:
+        response.raise_for_status()
+        content = b""
+        for chunk in response.iter_content(chunk_size=65536):
+            content += chunk
+            if len(content) > MAX_CONFIG_RESPONSE_BYTES:
+                raise ConfigDownloadError(
+                    f"Config response from {url} exceeded "
+                    f"{MAX_CONFIG_RESPONSE_BYTES} bytes"
+                )
+        return content
 
 
 class Severity(str, Enum):

--- a/atmos_validation/validate_netcdf/validation_settings.py
+++ b/atmos_validation/validate_netcdf/validation_settings.py
@@ -9,22 +9,15 @@ from typing import List
 CHECK_MIN_MAX_FULL: str = "--check-min-max-full"
 SKIP_MIN_MAX_CHECK: str = "--skip-random-min-max-check"
 SKIP_WARNINGS: str = "--skip-warnings"
-URL_TO_PARAMETERS: str = "--set-url-to-parameters="
-DEFAULT_URL_TO_PARAMETERS: str = "https://atmos.app.radix.equinor.com/config/parameters"
+URL_TO_PARAMETERS: str = "https://atmos.app.radix.equinor.com/config/parameters"
+URL_TO_INST_TYPES: str = "https://atmos.app.radix.equinor.com/config/installation-types"
+URL_TO_DATA_USABILITY: str = "https://atmos.app.radix.equinor.com/config/data-usability"
 SETTINGS = set()
 
 
 def apply_settings(optional_args: List[str]):
     for arg in optional_args:
         SETTINGS.add(arg)
-
-
-def get_url_to_parameters() -> str:
-    for arg in SETTINGS:
-        if str(arg).startswith(URL_TO_PARAMETERS):
-            return str(arg).split(URL_TO_PARAMETERS, 1)[1].strip()
-    # Not supplied, return default
-    return DEFAULT_URL_TO_PARAMETERS
 
 
 def should_skip_min_max_check() -> bool:

--- a/atmos_validation/validate_netcdf/validators/file_attributes.py
+++ b/atmos_validation/validate_netcdf/validators/file_attributes.py
@@ -1,4 +1,3 @@
-import urllib.request
 from typing import List
 
 import xarray as xr
@@ -14,8 +13,9 @@ from ...schemas import (
 from ...schemas.data_usability_level import DataUsabilityLevel
 from ...schemas.data_usability_levels import DataUsabilityLevels
 from ...schemas.metadata import DataType
-from ..utils import Severity, is_measurement, validation_node
+from ..utils import Severity, fetch_config_bytes, is_measurement, validation_node
 from ..validation_logger import log
+from ..validation_settings import URL_TO_DATA_USABILITY, URL_TO_INST_TYPES
 
 VALID_FINAL_REPORT_EXTENSIONS = ["docx", "pdf", "ppt", "pptx"]
 
@@ -151,14 +151,12 @@ def installation_type_validator(ds: xr.Dataset) -> List[str]:
 
 
 def load_valid_installation_types() -> List[str]:
-    url = "https://atmos.app.radix.equinor.com/config/installation-types"
     log.debug("download installation types")
-    with urllib.request.urlopen(url) as response:
-        data = response.read()
-        parsed_response = InstallationTypes(
-            configs=TypeAdapter(List[InstallationType]).validate_json(data)
-        ).configs
-        return [entry.installation_type for entry in parsed_response]
+    data = fetch_config_bytes(URL_TO_INST_TYPES)
+    parsed_response = InstallationTypes(
+        configs=TypeAdapter(List[InstallationType]).validate_json(data)
+    ).configs
+    return [entry.installation_type for entry in parsed_response]
 
 
 @validation_node(severity=Severity.ERROR)
@@ -185,14 +183,12 @@ def data_usability_validator(ds: xr.Dataset) -> List[str]:
 
 
 def load_valid_data_usability_levels() -> List[str]:
-    url = "https://atmos.app.radix.equinor.com/config/data-usability"
     log.debug("download data usabilities")
-    with urllib.request.urlopen(url) as response:
-        data = response.read()
-        parsed_response = DataUsabilityLevels(
-            configs=TypeAdapter(List[DataUsabilityLevel]).validate_json(data)
-        ).configs
-        return [entry.level for entry in parsed_response]
+    data = fetch_config_bytes(URL_TO_DATA_USABILITY)
+    parsed_response = DataUsabilityLevels(
+        configs=TypeAdapter(List[DataUsabilityLevel]).validate_json(data)
+    ).configs
+    return [entry.level for entry in parsed_response]
 
 
 @validation_node(severity=Severity.ERROR)

--- a/atmos_validation/validate_netcdf/validators/variables/variables_validator.py
+++ b/atmos_validation/validate_netcdf/validators/variables/variables_validator.py
@@ -1,13 +1,12 @@
-import urllib.request
 from typing import List
 
 import xarray as xr
 from pydantic import TypeAdapter
 
 from ....schemas import ParameterConfig, ParameterConfigs
-from ...utils import Severity, is_measurement, validation_node
+from ...utils import Severity, fetch_config_bytes, is_measurement, validation_node
 from ...validation_logger import log
-from ...validation_settings import get_url_to_parameters
+from ...validation_settings import URL_TO_PARAMETERS
 from .sig_dig_validator import sig_dig_validator
 from .varattrs_validator import (
     var_allowed_instruments_validator,
@@ -21,12 +20,10 @@ from .varinterval_validator import SEED, varinterval_validator
 
 
 def load_parameter_config_from_endpoint():
-    url = get_url_to_parameters()
     log.debug("download parameters config")
-    with urllib.request.urlopen(url) as response:
-        data = response.read()
-        adapter = TypeAdapter(List[ParameterConfig])
-        return ParameterConfigs(configs=adapter.validate_json(data))
+    data = fetch_config_bytes(URL_TO_PARAMETERS)
+    adapter = TypeAdapter(List[ParameterConfig])
+    return ParameterConfigs(configs=adapter.validate_json(data))
 
 
 @validation_node(severity=Severity.ERROR)


### PR DESCRIPTION
## Summary

Addresses the MEDIUM network-hardening finding: the config downloads had no timeout or response-size limit, and the parameter URL was CLI-configurable without HTTPS/host restriction (a latent SSRF if arguments are ever exposed through a service).

## Changes

**Timeout + bounded response (requests instead of urllib):**
- New helper `fetch_config_bytes(url)` in `utils.py` — uses `requests` (already a project dependency) with a **10s timeout**, `raise_for_status()`, and a streamed **10 MiB response cap** (`ConfigDownloadError` if exceeded).
- Migrated all three `urllib.request.urlopen()` call sites to it:
  - `file_attributes.py` — `load_valid_installation_types`, `load_valid_data_usability_levels`
  - `variables/variables_validator.py` — `load_parameter_config_from_endpoint`

**Remove the attacker-influenced destination:**
- Dropped the `--set-url-to-parameters=` CLI option and the `get_url_to_parameters()` resolver from `validation_settings.py`.
- Config endpoints are now fixed HTTPS constants (`URL_TO_PARAMETERS`, `URL_TO_INST_TYPES`, `URL_TO_DATA_USABILITY`). With no user-controlled URL there is no SSRF surface, so no host allowlist / scheme enforcement is required.

## Verification

- `pyright atmos_validation`: 0 errors.
- `ruff check`: clean.
- Tests pass, including `test_main`, `test_installation_types_validation`, `test_data_usability_validation` (exercise the migrated download paths).

## Notes

- Base is `fix/2514-external-reference-guard` intentionally (continues the stacked-branch chain); will follow onto main with the rest.
- `convert_ascii` already used `requests` with a timeout and is unaffected.