### PR TITLE
fix(validate-netcdf): isolate settings per call with ContextVar

### DIFF
--- a/atmos_validation/validate_netcdf/main.py
+++ b/atmos_validation/validate_netcdf/main.py
@@ -90,8 +90,7 @@ def validate(
         ValidationResult containing errors and warning from running validation
     """
     log.create_or_update_logger(injected_logger)
-    if additional_args:
-        validation_settings.apply_settings(additional_args)
+    validation_settings.apply_settings(additional_args or [])
 
     try:
         log.info("load dataset from path %s", path)

--- a/atmos_validation/validate_netcdf/tests/test_main.py
+++ b/atmos_validation/validate_netcdf/tests/test_main.py
@@ -56,8 +56,13 @@ def test_skip_warnings():
         path="examples/hindcast_example",
         additional_args=[validation_settings.SKIP_WARNINGS],
     )
-    # cleanup
-    validation_settings.SETTINGS.remove(validation_settings.SKIP_WARNINGS)
+
+
+def test_settings_do_not_leak_between_calls():
+    validation_settings.apply_settings([validation_settings.SKIP_WARNINGS])
+    assert validation_settings.should_skip_warnings()
+    validation_settings.apply_settings([])
+    assert not validation_settings.should_skip_warnings()
 
 
 def test_conflicting_coordinates_across_files(tmp_path):

--- a/atmos_validation/validate_netcdf/validation_settings.py
+++ b/atmos_validation/validate_netcdf/validation_settings.py
@@ -4,7 +4,8 @@ If this ever becomes an issue, an easy refactor would be to make the settings a 
 The other option would be to pass the settings down the entire tree of validators.
 """
 
-from typing import List
+from contextvars import ContextVar
+from typing import FrozenSet, List
 
 CHECK_MIN_MAX_FULL: str = "--check-min-max-full"
 SKIP_MIN_MAX_CHECK: str = "--skip-random-min-max-check"
@@ -12,21 +13,24 @@ SKIP_WARNINGS: str = "--skip-warnings"
 URL_TO_PARAMETERS: str = "https://atmos.app.radix.equinor.com/config/parameters"
 URL_TO_INST_TYPES: str = "https://atmos.app.radix.equinor.com/config/installation-types"
 URL_TO_DATA_USABILITY: str = "https://atmos.app.radix.equinor.com/config/data-usability"
-SETTINGS = set()
+
+# Per-call, thread/async-isolated so options never leak between validate() calls.
+_active_settings: ContextVar[FrozenSet[str]] = ContextVar(
+    "validation_settings", default=frozenset()
+)
 
 
-def apply_settings(optional_args: List[str]):
-    for arg in optional_args:
-        SETTINGS.add(arg)
+def apply_settings(optional_args: List[str]) -> None:
+    _active_settings.set(frozenset(optional_args))
 
 
 def should_skip_min_max_check() -> bool:
-    return SKIP_MIN_MAX_CHECK in SETTINGS
+    return SKIP_MIN_MAX_CHECK in _active_settings.get()
 
 
 def should_check_min_max_full() -> bool:
-    return CHECK_MIN_MAX_FULL in SETTINGS
+    return CHECK_MIN_MAX_FULL in _active_settings.get()
 
 
 def should_skip_warnings() -> bool:
-    return SKIP_WARNINGS in SETTINGS
+    return SKIP_WARNINGS in _active_settings.get()


### PR DESCRIPTION
## Summary

Fixes the MEDIUM finding that process-global settings leak between calls. Options were accumulated in a module-level `set` that was never reset, so they leaked across sequential `validate()` calls, resolved duplicates nondeterministically, and made concurrent validation unsafe.

## Change

- Replaced `SETTINGS = set()` in `validation_settings.py` with `_active_settings: ContextVar[FrozenSet[str]]` (default empty).
- `apply_settings()` now **replaces** the value with a fresh `frozenset` instead of accumulating; the `should_*()` readers read from `_active_settings.get()`.
- `validate()` now calls `apply_settings(additional_args or [])` on **every** invocation (previously only when args were supplied), so each call starts from a clean set — no explicit reset needed since it's set fresh each time.
- Removed the manual `SETTINGS.remove(...)` cleanup in `test_main` and added `test_settings_do_not_leak_between_calls`.

## Why ContextVar

The flags are read deep in the validator tree (the `validation_node` decorator and `varinterval_validator`), so threading a settings object through every signature would be invasive. A `ContextVar` keeps all existing call sites unchanged while giving per-thread and per-async-task isolation.

## Result

- Sequential leak between library calls → fixed (fresh frozenset per call).
- Nondeterministic duplicate resolution → fixed (immutable frozenset; the only value-bearing option, the parameter URL, was already removed).
- Thread/async safety → fixed (`ContextVar` values are isolated per thread/task; the one-shot CLI is unaffected).

## Verification

- `pyright atmos_validation`: 0 errors.
- `ruff check`: clean.
- `test_main` passes (6 tests, incl. the new isolation test).

## Notes

- Base is `fix/2514-network-hardening` (continues the stacked-branch chain).