### PR TITLE
ci: pin actions to commit SHAs and harden release pipeline

### DIFF
--- a/.github/workflows/ci-conventional-commit-linter.yml
+++ b/.github/workflows/ci-conventional-commit-linter.yml
@@ -24,6 +24,6 @@ jobs:
 
       - name: Lint pull request title
         if: '!steps.check.outputs.skip'
-        uses: jef/conventional-commits-pr-action@v1
+        uses: jef/conventional-commits-pr-action@2ee589f151916f92da5e2887c38d5fe6402e803c # v1.3.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-cov-comment.yml
+++ b/.github/workflows/ci-cov-comment.yml
@@ -14,7 +14,7 @@ jobs:
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Post comment
-        uses: py-cov-action/python-coverage-comment-action@v3
+        uses: py-cov-action/python-coverage-comment-action@a05be3d2e8a6272d3ef5fb2840ab20368bb2eb71 # v4.3
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_PR_RUN_ID: ${{ github.event.workflow_run.id }}

--- a/.github/workflows/ci-doctest.yml
+++ b/.github/workflows/ci-doctest.yml
@@ -11,10 +11,10 @@ jobs:
     name: Check documentation <--> code consistency
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 16
+          node-version: 20
       - run: |
           npm install embedme -g
           shopt -s globstar

--- a/.github/workflows/ci-lint-pr.yml
+++ b/.github/workflows/ci-lint-pr.yml
@@ -11,14 +11,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
       
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d # v10.0.0
     
       - name: Install dependencies
         run: uv sync

--- a/.github/workflows/ci-test-pr.yml
+++ b/.github/workflows/ci-test-pr.yml
@@ -16,10 +16,10 @@ jobs:
         python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
       
@@ -27,7 +27,7 @@ jobs:
         run: python -c "import sys; print(sys.version)"
       
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d # v10.0.0
     
       - name: Install dependencies
         run: |
@@ -41,7 +41,7 @@ jobs:
         run: uv run coverage run -m pytest atmos_validation
 
       - name: Store coverage file
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-${{ matrix.python-version }}
           path: .coverage.${{ matrix.python-version }}
@@ -55,9 +55,9 @@ jobs:
         pull-requests: write
         contents: write
       steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-        - uses: actions/download-artifact@v4
+        - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
           id: download
           with:
             pattern: coverage-*
@@ -65,14 +65,14 @@ jobs:
 
         - name: Coverage comment
           id: coverage_comment
-          uses: py-cov-action/python-coverage-comment-action@v3
+          uses: py-cov-action/python-coverage-comment-action@a05be3d2e8a6272d3ef5fb2840ab20368bb2eb71 # v4.3
           with:
             GITHUB_TOKEN: ${{ github.token }}
             MERGE_COVERAGE_FILES: true
             MINIMUM_GREEN: 90
 
         - name: Store Pull Request comment to be posted
-          uses: actions/upload-artifact@v4
+          uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
           if: steps.coverage_comment.outputs.COMMENT_FILE_WRITTEN == 'true'
           with:
             name: python-coverage-comment-action

--- a/.github/workflows/pypi-publisher.yml
+++ b/.github/workflows/pypi-publisher.yml
@@ -18,25 +18,84 @@ permissions:
   contents: read
 
 jobs:
+  test:
+    name: Test, lint and type check
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d # v10.0.0
+
+      - name: Install dependencies
+        run: |
+          uv venv
+          uv pip install setuptools
+          uv sync
+
+      - name: Lint and type check
+        run: |
+          uv run ruff format atmos_validation --check
+          uv run ruff check atmos_validation
+          uv run pyright atmos_validation
+
+      - name: Run tests
+        run: uv run pytest atmos_validation
+
+  build:
+    name: Build and attest distribution
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.11'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d # v10.0.0
+
+      - name: Build package
+        run: uv build
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-path: 'dist/*'
+
+      - name: Upload distribution artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dist
+          path: dist/
+
   pypi-publish:
     name: upload release to PyPI
+    needs: build
     runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write
     steps:
-    - uses: actions/checkout@v3
+      - name: Download distribution artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: dist
+          path: dist/
 
-    - name: Set up Python
-      uses: actions/setup-python@v3
-      with:
-        python-version: '3.11'    
-
-    - name: Install uv
-      uses: astral-sh/setup-uv@v6
-
-    - name: Build package
-      run: uv build
-
-    - name: Publish package distributions to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,7 +7,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v3
+      - uses: google-github-actions/release-please-action@db8f2c60ee802b3748b512940dde88eabd7b7e01 # v3
         with:
           token: ${{ secrets.PAT }}
           release-type: python


### PR DESCRIPTION
## Summary

Standalone supply-chain hardening for GitHub Actions, independent of the `fix/2514-*` chain. Based directly on `main`.

Addresses the MEDIUM finding: workflows used mutable major-version tags, and PyPI publication built and published directly with no test gate or artifact attestation.

## SHA-pin + upgrade all actions

| Action | Old | New (pinned to SHA) |
|---|---|---|
| actions/checkout | v3/v4 | v7.0.1 |
| actions/setup-python | v3/v4 | v7.0.0 |
| actions/setup-node | v3 | v7.0.0 |
| actions/upload-artifact | v4 | v7.0.1 |
| actions/download-artifact | v4 | v8.0.1 |
| astral-sh/setup-uv | v6 | v10.0.0 |
| pypa/gh-action-pypi-publish | release/v1 | v1.14.2 |
| jef/conventional-commits-pr-action | v1 | v1.3.0 |
| py-cov-action/python-coverage-comment-action | v3 | v4.3 |
| actions/attest-build-provenance | — | v4.2.2 (new) |
| Node runtime (doctest) | 16 | 20 |

Every `uses:` is now pinned to a full commit SHA with a trailing `# vX.Y.Z` comment.

## Harden the publish workflow (`pypi-publisher.yml`)

Split the single build-and-publish job into a gated pipeline:
1. **test** — pytest + ruff + pyright across Python 3.11–3.14
2. **build** (`needs: test`) — `uv build`, `actions/attest-build-provenance` over `dist/*`, upload the dist artifact (`id-token`/`attestations: write`)
3. **pypi-publish** (`needs: build`) — download the artifact and publish

So a release can no longer be published without green tests, and every published artifact carries a signed SLSA build-provenance attestation.

## Deliberate exception

`release-please` stays on its **v3 SHA**. v4+ is manifest-based and drops the inline `release-type` / `package-name` / `changelog-types` inputs this workflow relies on; bumping it would break releases without adding `release-please-config.json` + `.release-please-manifest.json`. That's a separate, tested migration. (Note: v3 is on the deprecated `google-github-actions` org; the maintained fork is `googleapis/release-please-action`.)

## Verification

- All 7 workflow files parse as valid YAML.
- No `@vN` / `@release/` / `@main` refs remain (all SHA-pinned).
- py-cov-action v4.3 inputs/outputs (`GITHUB_TOKEN`, `MINIMUM_GREEN`, `MERGE_COVERAGE_FILES`, `COMMENT_FILE_WRITTEN`) confirmed unchanged from v3 — no wiring changes needed.

## Watch on first run

Multi-major bumps (download-artifact v4→v8, setup-uv v6→v10, py-cov-action v3→v4) couldn't be executed locally; inputs are unchanged, but worth watching the first CI run.