### PR TITLE
fix(validate-netcdf): validate coordinate value ranges

### DIFF
--- a/atmos_validation/validate_netcdf/tests/test_coordinate_values_validator.py
+++ b/atmos_validation/validate_netcdf/tests/test_coordinate_values_validator.py
@@ -1,0 +1,46 @@
+import numpy as np
+import xarray as xr
+
+from ..validators.dims.spatial_validators import coordinate_values_validator
+
+
+def test_valid_coordinates_pass():
+    with xr.open_dataset("examples/example_netcdf_measurement.nc") as ds:
+        assert coordinate_values_validator(ds) == []
+
+
+def test_lat_out_of_range_reported():
+    with xr.open_dataset("examples/example_netcdf_measurement.nc") as ds:
+        ds["LAT"].values[:] = 91.0
+        errors = coordinate_values_validator(ds)
+        assert len(errors) == 1
+        assert "LAT" in errors[0]
+        assert "[-90.0, 90.0]" in errors[0]
+
+
+def test_lon_out_of_range_reported():
+    with xr.open_dataset("examples/example_netcdf_measurement.nc") as ds:
+        ds["LON"].values[:] = -181.0
+        errors = coordinate_values_validator(ds)
+        assert len(errors) == 1
+        assert "LON" in errors[0]
+
+
+def test_non_finite_lat_reported():
+    with xr.open_dataset("examples/example_netcdf_measurement.nc") as ds:
+        ds["LAT"].values[:] = np.nan
+        errors = coordinate_values_validator(ds)
+        assert any("non-finite" in error and "LAT" in error for error in errors)
+
+
+def test_non_finite_height_reported():
+    with xr.open_dataset("examples/example_netcdf_measurement.nc") as ds:
+        length = ds.sizes["height_WD"]
+        ds = ds.assign_coords(height_WD=("height_WD", np.full(length, np.inf)))
+        errors = coordinate_values_validator(ds)
+        assert any("non-finite" in error and "height_WD" in error for error in errors)
+
+
+def test_missing_lat_lon_not_reported_here():
+    errors = coordinate_values_validator(xr.Dataset())
+    assert errors == []

--- a/atmos_validation/validate_netcdf/validators/dims/dims_validator.py
+++ b/atmos_validation/validate_netcdf/validators/dims/dims_validator.py
@@ -5,6 +5,7 @@ import xarray as xr
 from ...utils import Severity, validation_node
 from .dimvars_validator import dimvars_validator
 from .spatial_validators import (
+    coordinate_values_validator,
     lat_lon_validator,
     south_north_validator,
     west_east_validator,
@@ -20,4 +21,5 @@ def dims_validator(ds: xr.Dataset, paths: List[str]) -> List[str]:
         + south_north_validator(ds)
         + west_east_validator(ds)
         + lat_lon_validator(ds)
+        + coordinate_values_validator(ds)
     )

--- a/atmos_validation/validate_netcdf/validators/dims/spatial_validators.py
+++ b/atmos_validation/validate_netcdf/validators/dims/spatial_validators.py
@@ -5,9 +5,10 @@ parameters.json in the vardims_validator
 
 from typing import List
 
+import numpy as np
 import xarray as xr
 
-from ....schemas import SOUTH_NORTH, WEST_EAST
+from ....schemas import HEIGHT_DIM_PREFIX, SOUTH_NORTH, WEST_EAST
 from ...utils import Severity, validation_node
 
 REQUIRED_LAT_ATTRS = {
@@ -27,6 +28,9 @@ REQUIRED_LON_ATTRS = {
 }
 
 REQUIREDS_MAP = {"LAT": REQUIRED_LAT_ATTRS, "LON": REQUIRED_LON_ATTRS}
+
+LAT_MIN, LAT_MAX = -90.0, 90.0
+LON_MIN, LON_MAX = -180.0, 180.0
 
 
 @validation_node(severity=Severity.ERROR)
@@ -97,3 +101,46 @@ def south_north_validator(ds: xr.Dataset):
 def west_east_validator(ds: xr.Dataset):
     """Validate that the dataset has west_east as a dim with a length > 0"""
     return existence_validator(ds, WEST_EAST)
+
+
+@validation_node(severity=Severity.ERROR)
+def coordinate_values_validator(ds: xr.Dataset) -> List[str]:
+    """
+    Validates coordinate values: LAT/LON must be finite and within range,
+    and height coordinates must be finite.
+    """
+    result = []
+    result += _finite_and_in_range_validator(ds, "LAT", LAT_MIN, LAT_MAX)
+    result += _finite_and_in_range_validator(ds, "LON", LON_MIN, LON_MAX)
+    result += _height_values_validator(ds)
+    return result
+
+
+def _finite_and_in_range_validator(
+    ds: xr.Dataset, name: str, low: float, high: float
+) -> List[str]:
+    if name not in ds:
+        return []  # existence is reported by lat_lon_validator
+    values = np.asarray(ds[name].values, dtype=float)
+    result = []
+    if not np.isfinite(values).all():
+        result += [f"{name} contains non-finite values (NaN or inf)"]
+    finite = values[np.isfinite(values)]
+    if finite.size and (finite.min() < low or finite.max() > high):
+        result += [
+            f"{name} values must be within [{low}, {high}]. "
+            f"Found range [{finite.min()}, {finite.max()}]"
+        ]
+    return result
+
+
+def _height_values_validator(ds: xr.Dataset) -> List[str]:
+    result = []
+    for dim in ds.sizes:
+        dim = str(dim)
+        if not dim.startswith(HEIGHT_DIM_PREFIX) or dim not in ds:
+            continue
+        values = np.asarray(ds[dim].values, dtype=float)
+        if not np.isfinite(values).all():
+            result += [f"{dim} contains non-finite values (NaN or inf)"]
+    return result


### PR DESCRIPTION
Add coordinate_values_validator: LAT must be finite and within [-90, 90], LON
finite and within [-180, 180], and height coordinates must be finite. Wire it
into dims_validator. Existence of LAT/LON is still owned by lat_lon_validator,
so a missing coordinate is not reported here.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>