### PR TITLE
feat(validate-netcdf): add --random-seed option for deterministic sampling

### DIFF
--- a/atmos_validation/validate_netcdf/main.py
+++ b/atmos_validation/validate_netcdf/main.py
@@ -29,7 +29,9 @@ from .validation_logger import log
 from .validators.root_validator import ValidationResult, root_validator
 
 DOCSTRING = f"""
-Usage: python -m atmos_toolkit validate-dataset DIR_OR_FILE
+Usage: python -m atmos_toolkit validate-dataset DIR_OR_FILE [OPTIONS]
+
+Example: python -m atmos_toolkit validate-dataset my_dataset/ {validation_settings.RANDOM_SEED} 42
 
 Run validation on a hindcast or measurement dataset (NetCDF standard format check)
 
@@ -41,6 +43,7 @@ Options:
     \t\t\t\t\t Can be extremely slow for large datasets. Default behaviour is taking random samples.
     --{validation_settings.SKIP_MIN_MAX_CHECK} \t Skip random sample check for min/max values.
     --{validation_settings.SKIP_WARNINGS} \t\t\t Skip all checks that would only output a "WARNING".
+    --{validation_settings.RANDOM_SEED} <int> \t Fix the random seed so sampled checks are reproducible.
 """
 
 

--- a/atmos_validation/validate_netcdf/validation_settings.py
+++ b/atmos_validation/validate_netcdf/validation_settings.py
@@ -4,12 +4,17 @@ If this ever becomes an issue, an easy refactor would be to make the settings a 
 The other option would be to pass the settings down the entire tree of validators.
 """
 
+import random
+import sys
 from contextvars import ContextVar
-from typing import FrozenSet, List
+from typing import FrozenSet, List, Optional
+
+from .validation_logger import log
 
 CHECK_MIN_MAX_FULL: str = "--check-min-max-full"
 SKIP_MIN_MAX_CHECK: str = "--skip-random-min-max-check"
 SKIP_WARNINGS: str = "--skip-warnings"
+RANDOM_SEED: str = "--random-seed"
 URL_TO_PARAMETERS: str = "https://atmos.app.radix.equinor.com/config/parameters"
 URL_TO_INST_TYPES: str = "https://atmos.app.radix.equinor.com/config/installation-types"
 URL_TO_DATA_USABILITY: str = "https://atmos.app.radix.equinor.com/config/data-usability"
@@ -18,10 +23,31 @@ URL_TO_DATA_USABILITY: str = "https://atmos.app.radix.equinor.com/config/data-us
 _active_settings: ContextVar[FrozenSet[str]] = ContextVar(
     "validation_settings", default=frozenset()
 )
+_random_seed: ContextVar[Optional[int]] = ContextVar("random_seed", default=None)
 
 
 def apply_settings(optional_args: List[str]) -> None:
     _active_settings.set(frozenset(optional_args))
+    _random_seed.set(_parse_random_seed(optional_args))
+
+
+def _parse_random_seed(optional_args: List[str]) -> int:
+    for i, arg in enumerate(optional_args):
+        if arg == RANDOM_SEED:
+            if i + 1 >= len(optional_args):
+                raise ValueError(f"{RANDOM_SEED} requires an integer value")
+            return int(optional_args[i + 1])
+        if arg.startswith(f"{RANDOM_SEED}="):
+            seed = arg.split("=", 1)[1]
+            log.info("using random seed: %s", seed)
+            return int(seed)
+    seed = random.randrange(sys.maxsize)  # default random seed if not specified
+    log.info("using random seed: %s", seed)
+    return seed
+
+
+def get_random_seed() -> Optional[int]:
+    return _random_seed.get()
 
 
 def should_skip_min_max_check() -> bool:

--- a/atmos_validation/validate_netcdf/validation_settings.py
+++ b/atmos_validation/validate_netcdf/validation_settings.py
@@ -7,7 +7,7 @@ The other option would be to pass the settings down the entire tree of validator
 import random
 import sys
 from contextvars import ContextVar
-from typing import FrozenSet, List, Optional
+from typing import FrozenSet, List
 
 from .validation_logger import log
 
@@ -23,7 +23,7 @@ URL_TO_DATA_USABILITY: str = "https://atmos.app.radix.equinor.com/config/data-us
 _active_settings: ContextVar[FrozenSet[str]] = ContextVar(
     "validation_settings", default=frozenset()
 )
-_random_seed: ContextVar[Optional[int]] = ContextVar("random_seed", default=None)
+_random_seed: ContextVar[int] = ContextVar("random_seed")
 
 
 def apply_settings(optional_args: List[str]) -> None:
@@ -46,7 +46,7 @@ def _parse_random_seed(optional_args: List[str]) -> int:
     return seed
 
 
-def get_random_seed() -> Optional[int]:
+def get_random_seed() -> int:
     return _random_seed.get()
 
 

--- a/atmos_validation/validate_netcdf/validators/variables/sig_dig_validator.py
+++ b/atmos_validation/validate_netcdf/validators/variables/sig_dig_validator.py
@@ -1,4 +1,4 @@
-from random import randint
+import random
 from typing import List, Tuple, Union
 
 import xarray as xr
@@ -12,12 +12,15 @@ from ....schemas import (
     WEST_EAST,
     ParameterConfig,
 )
+from ... import validation_settings
 from ...utils import Severity, validation_node
 
 
 @validation_node(severity=Severity.WARNING)
 def sig_dig_validator(
-    data: xr.DataArray, expected: ParameterConfig, number_of_iterations: int = 100
+    data: xr.DataArray,
+    expected: ParameterConfig,
+    number_of_iterations: int = 100,
 ) -> List[str]:
     """
     Check if values have the correct minimum amount of significant decimals.
@@ -25,9 +28,10 @@ def sig_dig_validator(
     """
     results = []
     faults = 0
+    rand = random.Random(validation_settings.get_random_seed())
 
     for _ in range(number_of_iterations):
-        random_index = _get_random_index(data)
+        random_index = _get_random_index(data, rand)
         random_value = data[random_index]
         sig_digs = str(random_value.values)[::-1].find(".")
         if sig_digs == -1:
@@ -44,23 +48,26 @@ def sig_dig_validator(
     return results
 
 
-def _get_random_index(data: xr.DataArray) -> Tuple[Union[int, slice], ...]:
+def _get_random_index(
+    data: xr.DataArray,
+    rand: random.Random,
+) -> Tuple[Union[int, slice], ...]:
     random_index = ()
     for dim in data.dims:
         if dim == TIME:
-            random_index += (randint(0, len(data[TIME]) - 1),)
+            random_index += (rand.randint(0, len(data[TIME]) - 1),)
         elif dim == f"{HEIGHT_DIM_PREFIX}{data.name}":
             random_index += (
-                randint(0, len(data[f"{HEIGHT_DIM_PREFIX}{data.name}"]) - 1),
+                rand.randint(0, len(data[f"{HEIGHT_DIM_PREFIX}{data.name}"]) - 1),
             )
         elif dim == SOUTH_NORTH:
-            random_index += (randint(0, len(data[SOUTH_NORTH]) - 1),)
+            random_index += (rand.randint(0, len(data[SOUTH_NORTH]) - 1),)
         elif dim == WEST_EAST:
-            random_index += (randint(0, len(data[WEST_EAST]) - 1),)
+            random_index += (rand.randint(0, len(data[WEST_EAST]) - 1),)
         elif dim == FREQUENCY:
-            random_index += (randint(0, len(data[FREQUENCY]) - 1),)
+            random_index += (rand.randint(0, len(data[FREQUENCY]) - 1),)
         elif dim == DIRECTION:
-            random_index += (randint(0, len(data[DIRECTION]) - 1),)
+            random_index += (rand.randint(0, len(data[DIRECTION]) - 1),)
         else:
             raise ValueError(
                 f"Invalid dimension {dim}, cannot validate interval of {data.name}"

--- a/atmos_validation/validate_netcdf/validators/variables/variables_validator.py
+++ b/atmos_validation/validate_netcdf/validators/variables/variables_validator.py
@@ -6,7 +6,7 @@ from pydantic import TypeAdapter
 from ....schemas import ParameterConfig, ParameterConfigs
 from ...utils import Severity, fetch_config_bytes, is_measurement, validation_node
 from ...validation_logger import log
-from ...validation_settings import URL_TO_PARAMETERS, get_random_seed
+from ...validation_settings import URL_TO_PARAMETERS
 from .sig_dig_validator import sig_dig_validator
 from .varattrs_validator import (
     var_allowed_instruments_validator,

--- a/atmos_validation/validate_netcdf/validators/variables/variables_validator.py
+++ b/atmos_validation/validate_netcdf/validators/variables/variables_validator.py
@@ -6,7 +6,7 @@ from pydantic import TypeAdapter
 from ....schemas import ParameterConfig, ParameterConfigs
 from ...utils import Severity, fetch_config_bytes, is_measurement, validation_node
 from ...validation_logger import log
-from ...validation_settings import URL_TO_PARAMETERS
+from ...validation_settings import URL_TO_PARAMETERS, get_random_seed
 from .sig_dig_validator import sig_dig_validator
 from .varattrs_validator import (
     var_allowed_instruments_validator,
@@ -16,7 +16,7 @@ from .varattrs_validator import (
     var_required_attr_values_validator,
 )
 from .vardims_validator import vardims_validator
-from .varinterval_validator import SEED, varinterval_validator
+from .varinterval_validator import varinterval_validator
 
 
 def load_parameter_config_from_endpoint():
@@ -31,7 +31,6 @@ def variables_validator(ds: xr.Dataset) -> List[str]:
     valids = load_parameter_config_from_endpoint().param_dict
     errors = []
 
-    log.info("using random seed: %s", SEED)
     for key in [str(k) for k in ds.keys()]:
         if key not in valids:
             errors += [f"{key} is not a valid key"]

--- a/atmos_validation/validate_netcdf/validators/variables/varinterval_validator.py
+++ b/atmos_validation/validate_netcdf/validators/variables/varinterval_validator.py
@@ -1,5 +1,4 @@
 import random
-import sys
 from typing import List, Tuple, Union
 
 import numpy as np
@@ -18,8 +17,6 @@ from ....schemas import (
 from ... import validation_settings
 from ...utils import Severity, validation_node
 from ...validation_logger import log
-
-SEED = random.randrange(sys.maxsize)
 
 
 def _compression_noise_tolerance(number_of_significant_decimals: int) -> float:
@@ -160,7 +157,7 @@ def varinterval_validator(
 def _check_randomly_selected_intervals_min_max(
     ds: xr.Dataset, actual: xr.DataArray, expected: ParameterConfig
 ):
-    rand = random.Random(SEED)
+    rand = random.Random(validation_settings.get_random_seed())
 
     slice_tuple = _get_slice_tuple(ds, actual, rand)
     vals = actual[slice_tuple]


### PR DESCRIPTION
## Summary
Adds a `--random-seed` option to `validate-netcdf` so the random sampling used in
validation can be made reproducible. Previously the seed was generated fresh on every
run, so sampled checks (min/max intervals, significant digits) could give different
results run-to-run. With a fixed seed, the same input yields the same outcome every time.
