### PR TITLE
feat(validate-netcdf): add --sample-size option (default 5000)

### DIFF
--- a/atmos_validation/validate_netcdf/main.py
+++ b/atmos_validation/validate_netcdf/main.py
@@ -44,6 +44,7 @@ Options:
     --{validation_settings.SKIP_MIN_MAX_CHECK} \t Skip random sample check for min/max values.
     --{validation_settings.SKIP_WARNINGS} \t\t\t Skip all checks that would only output a "WARNING".
     --{validation_settings.RANDOM_SEED} <int> \t Fix the random seed so sampled checks are reproducible.
+    --{validation_settings.SAMPLE_SIZE} <int> \t Number of timestamps to sample per variable (default {validation_settings.DEFAULT_SAMPLE_SIZE}).
 """
 
 

--- a/atmos_validation/validate_netcdf/validation_settings.py
+++ b/atmos_validation/validate_netcdf/validation_settings.py
@@ -15,6 +15,8 @@ CHECK_MIN_MAX_FULL: str = "--check-min-max-full"
 SKIP_MIN_MAX_CHECK: str = "--skip-random-min-max-check"
 SKIP_WARNINGS: str = "--skip-warnings"
 RANDOM_SEED: str = "--random-seed"
+SAMPLE_SIZE: str = "--sample-size"
+DEFAULT_SAMPLE_SIZE: int = 5000
 URL_TO_PARAMETERS: str = "https://atmos.app.radix.equinor.com/config/parameters"
 URL_TO_INST_TYPES: str = "https://atmos.app.radix.equinor.com/config/installation-types"
 URL_TO_DATA_USABILITY: str = "https://atmos.app.radix.equinor.com/config/data-usability"
@@ -24,11 +26,15 @@ _active_settings: ContextVar[FrozenSet[str]] = ContextVar(
     "validation_settings", default=frozenset()
 )
 _random_seed: ContextVar[int] = ContextVar("random_seed")
+_sample_size: ContextVar[int] = ContextVar(
+    "sample_size", default=DEFAULT_SAMPLE_SIZE
+)
 
 
 def apply_settings(optional_args: List[str]) -> None:
     _active_settings.set(frozenset(optional_args))
     _random_seed.set(_parse_random_seed(optional_args))
+    _sample_size.set(_parse_sample_size(optional_args))
 
 
 def _parse_random_seed(optional_args: List[str]) -> int:
@@ -48,6 +54,21 @@ def _parse_random_seed(optional_args: List[str]) -> int:
 
 def get_random_seed() -> int:
     return _random_seed.get()
+
+
+def _parse_sample_size(optional_args: List[str]) -> int:
+    for i, arg in enumerate(optional_args):
+        if arg == SAMPLE_SIZE:
+            if i + 1 >= len(optional_args):
+                raise ValueError(f"{SAMPLE_SIZE} requires an integer value")
+            return int(optional_args[i + 1])
+        if arg.startswith(f"{SAMPLE_SIZE}="):
+            return int(arg.split("=", 1)[1])
+    return DEFAULT_SAMPLE_SIZE
+
+
+def get_sample_size() -> int:
+    return _sample_size.get()
 
 
 def should_skip_min_max_check() -> bool:

--- a/atmos_validation/validate_netcdf/validation_settings.py
+++ b/atmos_validation/validate_netcdf/validation_settings.py
@@ -26,9 +26,7 @@ _active_settings: ContextVar[FrozenSet[str]] = ContextVar(
     "validation_settings", default=frozenset()
 )
 _random_seed: ContextVar[int] = ContextVar("random_seed")
-_sample_size: ContextVar[int] = ContextVar(
-    "sample_size", default=DEFAULT_SAMPLE_SIZE
-)
+_sample_size: ContextVar[int] = ContextVar("sample_size", default=DEFAULT_SAMPLE_SIZE)
 
 
 def apply_settings(optional_args: List[str]) -> None:

--- a/atmos_validation/validate_netcdf/validators/variables/varinterval_validator.py
+++ b/atmos_validation/validate_netcdf/validators/variables/varinterval_validator.py
@@ -25,9 +25,9 @@ def _compression_noise_tolerance(number_of_significant_decimals: int) -> float:
 
 
 def _get_random_time_slice(actual: xr.DataArray, rand: random.Random) -> slice:
-    """To save processing time we only check 5000 timestamps random samples"""
+    """To save processing time we only check a random sample of timestamps"""
     len_time = len(actual.Time)
-    sample_size = 5000
+    sample_size = validation_settings.get_sample_size()
     if len_time > sample_size * 2:
         start = rand.randint(0, len_time - sample_size - 1)
         time_slice = slice(start, start + sample_size)


### PR DESCRIPTION
## Summary
Adds a `--sample-size` option to `validate-netcdf` to control how many timestamps are
sampled per variable during the min/max interval check. Defaults to 5000 (previous
hardcoded value), so behaviour is unchanged unless the flag is set.